### PR TITLE
feat: added inline support in composer

### DIFF
--- a/src/store/integrations/composer.tsx
+++ b/src/store/integrations/composer.tsx
@@ -53,15 +53,13 @@ type ComposerProps = {
 	initialValue?: string;
 	/** The content of the editor (controlled mode) */
 	value?: string;
-	/** The base url to append to the resource urls */
-	baseAssetsUrl?: string;
 };
 
 const Composer: FC<ComposerProps> = ({
 	onEditorChange,
 	inline = false,
 	value,
-	baseAssetsUrl,
+
 	initialValue,
 	...rest
 }) => {
@@ -94,9 +92,9 @@ const Composer: FC<ComposerProps> = ({
 			<Editor
 				value={content}
 				init={{
-					skin_url: `${baseAssetsUrl}/tinymce/skins/ui/oxide`,
-					content_css: `${baseAssetsUrl}/tinymce/skins/content/default/content.css`,
+					selector: 'textarea',
 					min_height: 350,
+					content_css: false,
 					menubar: false,
 					statusbar: false,
 					branding: false,
@@ -114,9 +112,10 @@ const Composer: FC<ComposerProps> = ({
 						'anchor',
 						'searchreplace',
 						'code',
+						'edit',
+						'file',
 						'fullscreen',
 						'insertdatetime',
-						'media',
 						'table',
 						'paste',
 						'code',
@@ -125,10 +124,11 @@ const Composer: FC<ComposerProps> = ({
 						'directionality',
 						'autoresize'
 					],
+					object_resizing: 'img',
 					toolbar: inline
 						? false
 						: // eslint-disable-next-line max-len
-						  'fontselect fontsizeselect formatselect | bold italic underline strikethrough | removeformat code | alignleft aligncenter alignright alignjustify | forecolor backcolor | bullist numlist outdent indent | ltr rtl',
+						  'fontselect fontsizeselect formatselect | bold italic underline strikethrough | removeformat code | alignleft aligncenter alignright alignjustify | forecolor backcolor | bullist numlist outdent indent | ltr rtl | insertfile image ',
 					quickbars_insert_toolbar: inline ? 'bullist numlist' : '',
 					quickbars_selection_toolbar: inline
 						? 'bold italic underline | forecolor backcolor | removeformat | quicklink'

--- a/src/store/integrations/composer.tsx
+++ b/src/store/integrations/composer.tsx
@@ -53,13 +53,15 @@ type ComposerProps = {
 	initialValue?: string;
 	/** The content of the editor (controlled mode) */
 	value?: string;
+	/** The base url to append to the resource urls */
+	baseAssetsUrl?: string;
 };
 
 const Composer: FC<ComposerProps> = ({
 	onEditorChange,
 	inline = false,
 	value,
-
+	baseAssetsUrl,
 	initialValue,
 	...rest
 }) => {
@@ -81,7 +83,7 @@ const Composer: FC<ComposerProps> = ({
 			setContent(value);
 		}
 	}, [value]);
-
+	console.log('xxx:', { baseAssetsUrl: `${baseAssetsUrl}/tinymce/skins/ui/oxide` });
 	return (
 		<Container
 			height="100%"
@@ -92,30 +94,32 @@ const Composer: FC<ComposerProps> = ({
 			<Editor
 				value={content}
 				init={{
-					selector: 'textarea',
+					// skin_url: `${baseAssetsUrl}/tinymce/skins/ui/oxide`,
+					content_css: `${baseAssetsUrl}/tinymce/skins/content/default/content.css`,
 					min_height: 350,
-					content_css: false,
 					menubar: false,
 					statusbar: false,
 					branding: false,
 					resize: true,
 					inline,
+					object_resizing: 'img',
 					plugins: [
 						'advlist',
 						'autolink',
 						'lists',
 						'link',
 						'image',
+						'edit',
+						'file',
 						'charmap',
 						'print',
 						'preview',
 						'anchor',
 						'searchreplace',
 						'code',
-						'edit',
-						'file',
 						'fullscreen',
 						'insertdatetime',
+						'media',
 						'table',
 						'paste',
 						'code',
@@ -124,7 +128,6 @@ const Composer: FC<ComposerProps> = ({
 						'directionality',
 						'autoresize'
 					],
-					object_resizing: 'img',
 					toolbar: inline
 						? false
 						: // eslint-disable-next-line max-len
@@ -134,7 +137,8 @@ const Composer: FC<ComposerProps> = ({
 						? 'bold italic underline | forecolor backcolor | removeformat | quicklink'
 						: 'quicklink',
 					contextmenu: inline ? '' : '',
-					toolbar_mode: 'wrap'
+					toolbar_mode: 'wrap',
+					forced_root_block: 'pre'
 				}}
 				onEditorChange={_onEditorChange}
 				{...rest}


### PR DESCRIPTION
After going through the official Documentation -https://www.tiny.cloud/docs-3x/api/class_tinymce.Editor.html  I didn't find anything regarding the prop **skin_url** but in one blog that only importing the css file is enough and it's already in the import ,also I didn't find any issue in removing it.