### PR TITLE
fix: chips in search are splitted if typed

### DIFF
--- a/src/search/search-bar.tsx
+++ b/src/search/search-bar.tsx
@@ -382,7 +382,7 @@ export const SearchBar: FC = () => {
 								<ModuleSelector />
 							</Container>
 							<StyledContainer orientation="horizontal">
-								<StyledChipInput
+								<ChipInput
 									disabled={searchDisabled}
 									inputRef={inputRef}
 									value={inputState}
@@ -390,8 +390,7 @@ export const SearchBar: FC = () => {
 									options={options}
 									placeholder={placeholder}
 									confirmChipOnBlur={false}
-									confirmChipOnSpace={false}
-									separators={['Enter', 'NumpadEnter', 'Comma']}
+									separators={['Enter', 'NumpadEnter', 'Comma', 'Space']}
 									background={searchDisabled ? 'gray5' : 'gray6'}
 									style={{
 										cursor: 'pointer',

--- a/src/search/search-bar.tsx
+++ b/src/search/search-bar.tsx
@@ -382,7 +382,7 @@ export const SearchBar: FC = () => {
 								<ModuleSelector />
 							</Container>
 							<StyledContainer orientation="horizontal">
-								<ChipInput
+								<StyledChipInput
 									disabled={searchDisabled}
 									inputRef={inputRef}
 									value={inputState}


### PR DESCRIPTION
Chips are splitted after spaces in case of typing, they are not splitted in case of copy paste