### PR TITLE
fix: avoid loading fonts from ds to prevent slow loading of module

### DIFF
--- a/carbonio.webpack.js
+++ b/carbonio.webpack.js
@@ -114,5 +114,15 @@ module.exports = (conf, pkg, options, mode) => {
 		]
 	};
 	conf.externals = {};
+	conf.module.rules = [
+		...conf.module.rules,
+		{
+			test: /\.(woff(2)?|ttf|eot)$/,
+			type: 'asset/resource',
+			generator: {
+				filename: './files/[name][ext]'
+			}
+		}
+	];
 	return conf;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
+				"@fontsource/roboto": "^4.5.7",
 				"@sentry/browser": "^6.17.7",
 				"@tinymce/tinymce-react": "^3.13.0",
 				"@zextras/carbonio-design-system": "^1.0.1",
@@ -2306,6 +2307,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/@fontsource/roboto": {
+			"version": "4.5.8",
+			"resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
+			"integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA=="
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.5.0",
@@ -17177,6 +17183,11 @@
 					"dev": true
 				}
 			}
+		},
+		"@fontsource/roboto": {
+			"version": "4.5.8",
+			"resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
+			"integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA=="
 		},
 		"@humanwhocodes/config-array": {
 			"version": "0.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
 				"@types/ua-parser-js": "^0.7.36",
 				"@types/webpack-env": "1.16.3",
 				"@zextras/carbonio-ui-configs": "^0.1.11",
-				"@zextras/carbonio-ui-sdk": "^1.4.0",
+				"@zextras/carbonio-ui-sdk": "^1.5.0",
 				"autoprefixer": "10.4.2",
 				"babel-jest": "27.3.1",
 				"babel-loader": "8.2.3",
@@ -4046,9 +4046,9 @@
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-sdk": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-sdk/-/carbonio-ui-sdk-1.4.0.tgz",
-			"integrity": "sha512-7v2zlZNfivUNUNo61e5lCBY8nU9qz9B1O8A7CjIE75sn/Q0ox2ygJDrBL0pVRXD4aud9KQTH31x/HLLjrucO/w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-sdk/-/carbonio-ui-sdk-1.5.0.tgz",
+			"integrity": "sha512-/i5+EhtBYESjCTrKilJ/u/z9nbeqh5b9F7LMHd2D2n2cfTIFWpp2Q/xaGoxSZgYRPHjMZ7vLOOze02+kEYAtOw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.7",
@@ -18371,9 +18371,9 @@
 			}
 		},
 		"@zextras/carbonio-ui-sdk": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-sdk/-/carbonio-ui-sdk-1.4.0.tgz",
-			"integrity": "sha512-7v2zlZNfivUNUNo61e5lCBY8nU9qz9B1O8A7CjIE75sn/Q0ox2ygJDrBL0pVRXD4aud9KQTH31x/HLLjrucO/w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-sdk/-/carbonio-ui-sdk-1.5.0.tgz",
+			"integrity": "sha512-/i5+EhtBYESjCTrKilJ/u/z9nbeqh5b9F7LMHd2D2n2cfTIFWpp2Q/xaGoxSZgYRPHjMZ7vLOOze02+kEYAtOw==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
 		"webpack-merge": "5.8.0"
 	},
 	"dependencies": {
+		"@fontsource/roboto": "^4.5.7",
 		"@sentry/browser": "^6.17.7",
 		"@tinymce/tinymce-react": "^3.13.0",
 		"@zextras/carbonio-design-system": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"@types/ua-parser-js": "^0.7.36",
 		"@types/webpack-env": "1.16.3",
 		"@zextras/carbonio-ui-configs": "^0.1.11",
-		"@zextras/carbonio-ui-sdk": "^1.4.0",
+		"@zextras/carbonio-ui-sdk": "^1.5.0",
 		"autoprefixer": "10.4.2",
 		"babel-jest": "27.3.1",
 		"babel-loader": "8.2.3",

--- a/src/boot/theme-provider.tsx
+++ b/src/boot/theme-provider.tsx
@@ -173,7 +173,7 @@ export const ThemeProvider = ({ children }: ThemeProviderProps): JSX.Element => 
 	}, [localStorageSettings]);
 
 	return (
-		<UIThemeProvider extension={aggregatedExtensions} loadDefaultFont>
+		<UIThemeProvider extension={aggregatedExtensions}>
 			<ThemeCallbacksContext.Provider value={{ addExtension, setDarkReaderState }}>
 				<GlobalStyle baseFontSize={baseFontSize} />
 				{children}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,10 @@ import './index.css';
 import React, { lazy, Suspense } from 'react';
 import { render } from 'react-dom';
 import LoadingView from './boot/splash';
+import '@fontsource/roboto/300.css';
+import '@fontsource/roboto/400.css';
+import '@fontsource/roboto/500.css';
+import '@fontsource/roboto/700.css';
 
 window.addEventListener('contextmenu', (ev) => {
 	if (


### PR DESCRIPTION
Fonts loaded from DS bundle are slowing down a lot the loading of the modules since the request to download the inline font is taking more than 2 seconds to response.

Restore the usage of @fontsource/roboto to load a local copy of the fonts. Update webpack config to place the fonts where fontsource is loading them from.

refs: SHELL-31