### PR TITLE
refactor: extended the type of the AccountSettings properties

### DIFF
--- a/src/settings/accounts-settings.tsx
+++ b/src/settings/accounts-settings.tsx
@@ -90,7 +90,7 @@ const getAvailableEmailAddresses = (account: Account, settings: AccountSettings)
 	// Adds all the aliases
 	if (settings.attrs.zimbraMailAlias) {
 		if (isArray(settings.attrs.zimbraMailAlias)) {
-			result.push(...settings.attrs.zimbraMailAlias as string[]);
+			result.push(...(settings.attrs.zimbraMailAlias as string[]));
 		} else {
 			result.push(String(settings.attrs.zimbraMailAlias));
 		}

--- a/src/settings/accounts-settings.tsx
+++ b/src/settings/accounts-settings.tsx
@@ -90,7 +90,7 @@ const getAvailableEmailAddresses = (account: Account, settings: AccountSettings)
 	// Adds all the aliases
 	if (settings.attrs.zimbraMailAlias) {
 		if (isArray(settings.attrs.zimbraMailAlias)) {
-			result.push(...settings.attrs.zimbraMailAlias);
+			result.push(...settings.attrs.zimbraMailAlias as string[]);
 		} else {
 			result.push(String(settings.attrs.zimbraMailAlias));
 		}

--- a/types/account/index.d.ts
+++ b/types/account/index.d.ts
@@ -51,8 +51,8 @@ export type DelegateProps = {
 };
 
 export type AccountSettings = {
-	attrs: Record<string, string | number>;
-	prefs: Record<string, string | number>;
+	attrs: Record<string, string | number | Array<string | number>>;
+	prefs: Record<string, string | number | Array<string | number>>;
 	props: Array<ZimletProp>;
 };
 


### PR DESCRIPTION
Extended the type of `prefs` and `attrs` of the `AccountSettings` type to support preferences with array values 

refs: SHELL-66