### PR TITLE
feat(settings): list delegated addresses of sendOfBehalfOf type

### DIFF
--- a/src/settings/accounts-settings.tsx
+++ b/src/settings/accounts-settings.tsx
@@ -75,7 +75,7 @@ const getAvailableEmailAddresses = (account: Account, settings: AccountSettings)
 	// Adds the email addresses of all the shared accounts
 	if (account.rights?.targets) {
 		account.rights?.targets.forEach((target) => {
-			if (target.right === 'sendAs' && target.target) {
+			if (target.target && (target.right === 'sendAs' || target.right === 'sendOnBehalfOf')) {
 				target.target.forEach((user) => {
 					if (user.type === 'account' && user.email) {
 						user.email.forEach((email) => {


### PR DESCRIPTION
Changed the _getAvailableAddresses_ function in order to list also all the delegated address of type _sendOnBehalfOf_

refs: SHELL-72