### PR TITLE
HOTFIX NoOp retry interval

### DIFF
--- a/src/network/fetch.ts
+++ b/src/network/fetch.ts
@@ -18,19 +18,7 @@ import { report } from '../reporting';
 import { useAccountStore } from '../store/account';
 import { IS_STANDALONE, SHELL_APP_ID } from '../constants';
 import { useNetworkStore } from '../store/network';
-import { handleSync } from '../store/network/utils';
-
-/**
- * Polling interval to use if the long polling delay
- * is not allowed for the user
- */
-const POLLING_NOWAIT_INTERVAL = 10_000;
-
-/**
- * Polling interval to use if a previous request failed
- * with a 500 error
- */
-const POLLING_RETRY_INTERVAL = 60_000;
+import { getPollingInterval, handleSync } from '../store/network/utils';
 
 export const fetchNoOp = (): void => {
 	// eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -101,26 +89,6 @@ const normalizeContext = (context: any): SoapContext => {
 		}));
 	}
 	return context;
-};
-
-/**
- * Return the polling interval for the next NoOp request.
- * The interval length depends on the user settings, but it can be
- * overridden by the server response/errors
- * @param res
- */
-const getPollingInterval = <R>(res: SoapResponse<R>): number => {
-	const { pollingInterval } = useNetworkStore.getState();
-	const waitDisallowed = (res?.Body as { waitDisallowed?: number })?.waitDisallowed;
-	const fault = res?.Body?.Fault;
-	if (fault) {
-		return POLLING_RETRY_INTERVAL;
-	}
-	if (waitDisallowed) {
-		return POLLING_NOWAIT_INTERVAL;
-	}
-
-	return pollingInterval;
 };
 
 const handleResponse = <R>(api: string, res: SoapResponse<R>): R | ErrorSoapBodyResponse => {

--- a/src/network/get-info.ts
+++ b/src/network/get-info.ts
@@ -8,25 +8,11 @@ import { filter } from 'lodash';
 import { SHELL_APP_ID } from '../constants';
 import { useAppStore } from '../store/app';
 import { normalizeAccount } from '../store/account/normalization';
-import { AccountSettings, GetInfoResponse, CarbonioModule } from '../../types';
+import { GetInfoResponse, CarbonioModule } from '../../types';
 import { getSoapFetch } from './fetch';
 import { useAccountStore } from '../store/account';
 import { useNetworkStore } from '../store/network';
-
-const parsePollingInterval = (settings: AccountSettings): number => {
-	const pollingPref = (settings.prefs?.zimbraPrefMailPollingInterval ?? '') as string;
-	if (pollingPref === '500') {
-		return 500;
-	}
-	const pollingValue = parseInt(pollingPref, 10);
-	if (Number.isNaN(pollingValue)) {
-		return 30000;
-	}
-	if (pollingPref.includes('m')) {
-		return pollingValue * 60 * 1000;
-	}
-	return pollingValue * 1000;
-};
+import { parsePollingInterval } from '../store/network/utils';
 
 export const getInfo = (): Promise<void> =>
 	fetch('/static/iris/components.json')

--- a/src/store/network/utils.ts
+++ b/src/store/network/utils.ts
@@ -5,11 +5,62 @@
  */
 
 import { forEach } from 'lodash';
-import { SoapContext } from '../../../types';
+import { AccountSettings, SoapContext, SoapResponse } from '../../../types';
 import { folderWorker, tagWorker } from '../../workers';
 import { useFolderStore } from '../folder';
 import { useTagStore } from '../tags';
 import { useNetworkStore } from './store';
+import { useAccountStore } from '../account';
+
+/**
+ * Polling interval to use if the long polling delay
+ * is not allowed for the user
+ */
+const POLLING_NOWAIT_INTERVAL = 10_000;
+
+/**
+ * Polling interval to use if a previous request failed
+ * with a 500 error
+ */
+const POLLING_RETRY_INTERVAL = 60_000;
+
+export const parsePollingInterval = (settings: AccountSettings): number => {
+	const pollingPref = (settings.prefs?.zimbraPrefMailPollingInterval ?? '') as string;
+	if (pollingPref === '500') {
+		return 500;
+	}
+	const pollingValue = parseInt(pollingPref, 10);
+	if (Number.isNaN(pollingValue)) {
+		return 30000;
+	}
+	if (pollingPref.includes('m')) {
+		return pollingValue * 60 * 1000;
+	}
+	return pollingValue * 1000;
+};
+
+/**
+ * Return the polling interval for the next NoOp request.
+ * The interval length depends on the user settings, but it can be
+ * overridden by the server response/errors
+ * @param res
+ */
+export const getPollingInterval = <R>(res: SoapResponse<R>): number => {
+	const { pollingInterval } = useNetworkStore.getState();
+	const { settings } = useAccountStore.getState();
+	const waitDisallowed = (res?.Body as { waitDisallowed?: number })?.waitDisallowed;
+	const fault = res?.Body?.Fault;
+	if (fault) {
+		return POLLING_RETRY_INTERVAL;
+	}
+	if (waitDisallowed) {
+		return POLLING_NOWAIT_INTERVAL;
+	}
+	if (!fault) {
+		return parsePollingInterval(settings);
+	}
+	return pollingInterval;
+};
 
 export const handleSync = ({ refresh, notify }: SoapContext): Promise<void> =>
 	new Promise((r) => {


### PR DESCRIPTION
The current logic that determine the next _NoOp_ request interval has been modified, in order to set a fixed 1 minute interval before the next attempt, and to set the default value (the one set on the user settings) when the next request doesn't fail.
  
refs: IRIS-4216