### PR TITLE
fix(types): add the signal parameter to the SoapFetch exported type

### DIFF
--- a/types/account/index.d.ts
+++ b/types/account/index.d.ts
@@ -24,7 +24,8 @@ export interface ZappDarkreaderModeZimletProp extends ZimletProp {
 export type SoapFetch = <Request, Response>(
 	api: string,
 	body: Request,
-	account?: string
+	account?: string,
+	signal?: AbortSignal
 ) => Promise<Response>;
 
 export type AccountState = {


### PR DESCRIPTION
Add the optional _signal_ parameter to the _SoapFetch_ exported type

refs: SHELL-133