### PR TITLE
fix: prevent click on board header only if a move occurs

### DIFF
--- a/src/shell/hooks/useMove.ts
+++ b/src/shell/hooks/useMove.ts
@@ -19,7 +19,7 @@ type MoveOptions = {
 	keepSynchedWithStorage?: boolean;
 };
 
-export const BOARD_CURSOR_TIMEOUT = 100;
+export const BOARD_CURSOR_TIMEOUT = 250;
 
 function calcNewPosition(
 	from: SizeAndPosition & {
@@ -93,6 +93,8 @@ export const useMove = (
 
 	const onMouseMove = useCallback(
 		(mouseMoveEvent: MouseEvent) => {
+			// prevent clickable elements from being clicked if a move has been made
+			document.body.addEventListener('click', preventClick, { capture: true });
 			if (initialSizeAndPositionRef.current && elementToMoveRef.current) {
 				const offsetParent =
 					(elementToMoveRef.current.offsetParent instanceof HTMLElement &&
@@ -111,7 +113,7 @@ export const useMove = (
 				shouldUpdateLocalStorageRef.current = true;
 			}
 		},
-		[elementToMoveRef, moveElement]
+		[elementToMoveRef, moveElement, preventClick]
 	);
 
 	const enableMove = useCallback(() => {
@@ -119,12 +121,10 @@ export const useMove = (
 			document.activeElement.classList.add('no-active-background');
 		}
 		document.body.addEventListener('mousemove', onMouseMove);
-		// prevent clickable elements from being clicked if a move has been made
-		document.body.addEventListener('click', preventClick, { capture: true });
 		setGlobalCursor('move');
 		isMoveEnabledRef.current = true;
 		setIsMoving(true);
-	}, [onMouseMove, preventClick]);
+	}, [onMouseMove]);
 
 	const disableMove = useCallback(() => {
 		if (document.activeElement && document.activeElement instanceof HTMLElement) {


### PR DESCRIPTION
Increase the timeout after which the mouse press is considered a move

refs: SHELL-135