### PR TITLE
chore: update api-extractor config of report temp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ shell.iml
 .env
 carbonio.webpack.js
 src/constants/locales.js
+/temp

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -183,7 +183,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: "<projectFolder>/temp/"
      */
-     "reportTempFolder": "<projectFolder>/api-extractor/",
+     "reportTempFolder": "<projectFolder>/temp/",
 
     /**
      * Whether "forgotten exports" should be included in the API report file. Forgotten exports are declarations

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"postbuild:pkg": "rm carbonio.webpack.js src/constants/locales.js",
 		"prebuild:lib": "rm -rf lib",
 		"build:lib": "tsc -p tsconfig.lib.json && npx api-extractor run --verbose",
+		"build:lib:local": "tsc -p tsconfig.lib.json && npx api-extractor run --verbose --local",
 		"predeploy": "npm run prebuild:pkg",
 		"postdeploy": "npm run postbuild:pkg",
 		"deploy": "sdk deploy",


### PR DESCRIPTION
Distinguish the temp folder, to make api-extractor able to block a build if the temp report does not match the main report.
In order to update the main report, a manual run of the script `build:lib:local` is required.