### PR TITLE
CO-1133 let user manage allowing and blocking addresses in Carbonio CE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"i18next-http-backend": "^2.5.0",
 				"immer": "^10.0.3",
 				"lodash": "^4.17.21",
+				"moment": "^2.30.1",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2",
 				"react-i18next": "^12.3.1",
@@ -113,6 +114,9 @@
 					"optional": true
 				},
 				"lodash": {
+					"optional": true
+				},
+				"moment": {
 					"optional": true
 				},
 				"react": {
@@ -15373,6 +15377,14 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/moment": {
+			"version": "2.30.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
 		"i18next-http-backend": "^2.5.0",
 		"immer": "^10.0.3",
 		"lodash": "^4.17.21",
+		"moment": "^2.30.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"react-i18next": "^12.3.1",
@@ -147,6 +148,9 @@
 			"optional": true
 		},
 		"lodash": {
+			"optional": true
+		},
+		"moment": {
 			"optional": true
 		},
 		"react": {

--- a/src/boot/app/shared-libraries.ts
+++ b/src/boot/app/shared-libraries.ts
@@ -11,6 +11,7 @@ import * as ZappUI from '@zextras/carbonio-design-system';
 import * as Preview from '@zextras/carbonio-ui-preview';
 import * as Darkreader from 'darkreader';
 import * as Lodash from 'lodash';
+import * as Moment from 'moment';
 import * as ReactDOM from 'react-dom';
 import * as ReactI18n from 'react-i18next';
 import * as ReactRedux from 'react-redux';
@@ -25,6 +26,7 @@ export function injectSharedLibraries(): void {
 			'react-i18next': ReactI18n,
 			'react-redux': ReactRedux,
 			lodash: Lodash,
+			moment: Moment,
 			'react-router-dom': ReactRouterDom,
 			'styled-components': StyledComponents,
 			'@reduxjs/toolkit': ReduxJSToolkit,

--- a/src/network/edit-settings.ts
+++ b/src/network/edit-settings.ts
@@ -53,6 +53,22 @@ export const editSettings = (
 					).join('')}</ModifyPrefsRequest>`
 				: ''
 		}${
+			mods.attrs?.amavisWhitelistSender || mods.attrs?.amavisBlacklistSender
+				? `<ModifyWhiteBlackListRequest xmlns="urn:zimbraAccount">${
+						mods.attrs?.amavisWhitelistSender && isArray(mods.attrs?.amavisWhitelistSender)
+							? `<whiteList>${mods.attrs?.amavisWhitelistSender
+									.map((email) => `<addr>${email}</addr>`)
+									.join('')}</whiteList>`
+							: ''
+					}${
+						mods.attrs?.amavisBlacklistSender && isArray(mods.attrs?.amavisBlacklistSender)
+							? `<whiteList>${mods.attrs?.amavisBlacklistSender
+									.map((email) => `<addr>${email}</addr>`)
+									.join('')}</whiteList>`
+							: ''
+					}</ModifyWhiteBlackListRequest>`
+				: ''
+		}${
 			mods.identity?.modifyList
 				? map(
 						mods.identity.modifyList,


### PR DESCRIPTION
:bell: needed by https://github.com/zextras/carbonio-mails-ui/pull/591

Adds saving amavis whitelist and blacklist senders from attrs.

:warning: we need to remove moment dependency before merging