### PR TITLE
feat: warn user about incoming expiration of session

### DIFF
--- a/api-extractor/carbonio-shell-ui.api.md
+++ b/api-extractor/carbonio-shell-ui.api.md
@@ -1752,7 +1752,7 @@ interface ZimletProp {
 // lib/types/misc/index.d.ts:120:5 - (ae-forgotten-export) The symbol "Meta" needs to be exported by the entry point lib.d.ts
 // lib/types/misc/index.d.ts:124:5 - (ae-forgotten-export) The symbol "SoapRetentionPolicy" needs to be exported by the entry point lib.d.ts
 // lib/types/misc/index.d.ts:138:5 - (ae-forgotten-export) The symbol "SortBy" needs to be exported by the entry point lib.d.ts
-// lib/types/network/index.d.ts:107:5 - (ae-forgotten-export) The symbol "AccountACEInfo" needs to be exported by the entry point lib.d.ts
+// lib/types/network/index.d.ts:108:5 - (ae-forgotten-export) The symbol "AccountACEInfo" needs to be exported by the entry point lib.d.ts
 // lib/types/network/soap.d.ts:11:5 - (ae-forgotten-export) The symbol "NameSpace" needs to be exported by the entry point lib.d.ts
 // lib/types/network/soap.d.ts:65:5 - (ae-forgotten-export) The symbol "SoapSearchFolder" needs to be exported by the entry point lib.d.ts
 // lib/types/workers/index.d.ts:12:5 - (ae-forgotten-export) The symbol "SyncMessage" needs to be exported by the entry point lib.d.ts

--- a/src/boot/loader.test.tsx
+++ b/src/boot/loader.test.tsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { EventEmitter } from 'node:events';
 
@@ -14,9 +14,10 @@ import * as posthog from './posthog';
 import { LOGIN_V3_CONFIG_PATH } from '../constants';
 import { getGetInfoRequest } from '../mocks/handlers/getInfoRequest';
 import server, { waitForResponse } from '../mocks/server';
+import * as logout from '../network/logout';
 import { useLoginConfigStore } from '../store/login/store';
 import { spyOnPosthog } from '../tests/posthog-utils';
-import { controlConsoleError, setup } from '../tests/utils';
+import { controlConsoleError, setup, screen } from '../tests/utils';
 import type { AccountSettingsPrefs } from '../types/account';
 import * as utils from '../utils/utils';
 
@@ -216,4 +217,238 @@ describe('Loader', () => {
 			await waitFor(() => expect(enableTrackerFn).toHaveBeenLastCalledWith(false));
 		}
 	);
+
+	describe('Session expiration', () => {
+		it('should show a temporary snackbar when the session expires in 10 minutes', async () => {
+			const tenMinutes = 10 * 60 * 1000;
+			const tenSeconds = 10 * 1000;
+			server.use(
+				http.post('/service/soap/GetInfoRequest', getGetInfoRequest({ lifetime: tenMinutes + 2 }))
+			);
+			setup(<Loader />);
+			await act(async () => {
+				await jest.advanceTimersByTimeAsync(1);
+			});
+			expect(
+				screen.queryByText(
+					"Your session will expire in 10 minutes. After that, you'll be redirected to the login page."
+				)
+			).not.toBeInTheDocument();
+			await act(async () => {
+				await jest.advanceTimersByTimeAsync(1);
+			});
+			const snackbar = screen.getByText(
+				"Your session will expire in 10 minutes. After that, you'll be redirected to the login page."
+			);
+			expect(snackbar).toBeVisible();
+			await act(async () => {
+				await jest.advanceTimersByTimeAsync(tenSeconds);
+			});
+			expect(snackbar).not.toBeInTheDocument();
+		});
+
+		it('should show the go to login page action on the 10 minutes snackbar. Action calls logout', async () => {
+			const logoutFn = jest.spyOn(logout, 'logout').mockImplementation();
+			const tenMinutes = 10 * 60 * 1000;
+			server.use(
+				http.post('/service/soap/GetInfoRequest', getGetInfoRequest({ lifetime: tenMinutes }))
+			);
+			const { user } = setup(<Loader />);
+			await act(async () => {
+				await jest.advanceTimersToNextTimerAsync();
+			});
+			const goToLoginPageButton = await screen.findByRole('button', { name: /go to login page/i });
+			expect(goToLoginPageButton).toBeVisible();
+			await user.click(goToLoginPageButton);
+			expect(logoutFn).toHaveBeenCalled();
+		});
+
+		it('should show a permanent snackbar when the session expires in 3 minutes', async () => {
+			const threeMinutes = 3 * 60 * 1000;
+			const tenSeconds = 10 * 1000;
+			server.use(
+				http.post('/service/soap/GetInfoRequest', getGetInfoRequest({ lifetime: threeMinutes + 2 }))
+			);
+			setup(<Loader />);
+			await act(async () => {
+				await jest.advanceTimersByTimeAsync(1);
+			});
+			expect(
+				screen.queryByText(
+					"Your session will expire in 3 minutes. After that, you'll be redirected to the login page."
+				)
+			).not.toBeInTheDocument();
+			await act(async () => {
+				await jest.advanceTimersByTimeAsync(1);
+			});
+			const snackbar = await screen.findByText(
+				"Your session will expire in 3 minutes. After that, you'll be redirected to the login page."
+			);
+			expect(snackbar).toBeVisible();
+			await act(async () => {
+				await jest.advanceTimersByTimeAsync(tenSeconds);
+			});
+			expect(snackbar).toBeVisible();
+		});
+
+		it('should show the go to login page action on the 3 minutes snackbar. Action calls logout', async () => {
+			const logoutFn = jest.spyOn(logout, 'logout').mockImplementation();
+			const threeMinutes = 3 * 60 * 1000;
+			server.use(
+				http.post('/service/soap/GetInfoRequest', getGetInfoRequest({ lifetime: threeMinutes }))
+			);
+			const { user } = setup(<Loader />);
+			await act(async () => {
+				await jest.advanceTimersToNextTimerAsync();
+			});
+			const goToLoginPageButton = await screen.findByRole('button', { name: /go to login page/i });
+			expect(goToLoginPageButton).toBeVisible();
+			await user.click(goToLoginPageButton);
+			expect(logoutFn).toHaveBeenCalled();
+		});
+
+		it('should show a temporary snackbar when the session expires in 60 seconds', async () => {
+			jest.spyOn(logout, 'logout').mockImplementation();
+			const oneMinute = 60 * 1000;
+			server.use(
+				http.post('/service/soap/GetInfoRequest', getGetInfoRequest({ lifetime: oneMinute + 2 }))
+			);
+			setup(<Loader />);
+			await act(async () => {
+				await jest.advanceTimersByTimeAsync(1);
+			});
+			expect(
+				screen.queryByText(
+					"Your session will expire in 60 seconds. After that, you'll be redirected to the login page."
+				)
+			).not.toBeInTheDocument();
+			await act(async () => {
+				await jest.advanceTimersByTimeAsync(1);
+			});
+			const snackbar = await screen.findByText(
+				"Your session will expire in 60 seconds. After that, you'll be redirected to the login page."
+			);
+			expect(snackbar).toBeVisible();
+			await act(async () => {
+				await jest.advanceTimersByTimeAsync(oneMinute);
+			});
+			expect(snackbar).not.toBeInTheDocument();
+		});
+
+		it('should show the go to login page action on the 60 seconds snackbar. Action calls logout', async () => {
+			const logoutFn = jest.spyOn(logout, 'logout').mockImplementation();
+			const oneMinute = 60 * 1000;
+			server.use(
+				http.post('/service/soap/GetInfoRequest', getGetInfoRequest({ lifetime: oneMinute }))
+			);
+			const { user } = setup(<Loader />);
+			await act(async () => {
+				await jest.advanceTimersToNextTimerAsync();
+			});
+			const goToLoginPageButton = await screen.findByRole('button', { name: /go to login page/i });
+			expect(goToLoginPageButton).toBeVisible();
+			await user.click(goToLoginPageButton);
+			expect(logoutFn).toHaveBeenCalled();
+		});
+
+		it('should not show 10 minutes snackbar if session expires in less than 10 minutes', async () => {
+			const tenMinutes = 10 * 60 * 1000;
+			server.use(
+				http.post('/service/soap/GetInfoRequest', getGetInfoRequest({ lifetime: tenMinutes - 1 }))
+			);
+			setup(<Loader />);
+			await act(async () => {
+				await jest.advanceTimersToNextTimerAsync();
+			});
+			expect(
+				screen.queryByText(
+					"Your session will expire in 10 minutes. After that, you'll be redirected to the login page."
+				)
+			).not.toBeInTheDocument();
+		});
+
+		it('should not show the 3 minutes snackbar if the session expires in less than 3 minutes', async () => {
+			const threeMinutes = 3 * 60 * 1000;
+			server.use(
+				http.post('/service/soap/GetInfoRequest', getGetInfoRequest({ lifetime: threeMinutes - 1 }))
+			);
+			setup(<Loader />);
+			await act(async () => {
+				await jest.advanceTimersToNextTimerAsync();
+			});
+			expect(
+				screen.queryByText(
+					"Your session will expire in 3 minutes. After that, you'll be redirected to the login page."
+				)
+			).not.toBeInTheDocument();
+		});
+
+		it('should show the 60 seconds snackbar if the session expires in less than 60 seconds', async () => {
+			const oneMinute = 60 * 1000;
+			server.use(
+				http.post(
+					'/service/soap/GetInfoRequest',
+					getGetInfoRequest({ lifetime: oneMinute - 10000 })
+				)
+			);
+			setup(<Loader />);
+			await act(async () => {
+				await jest.advanceTimersToNextTimerAsync();
+			});
+			expect(
+				await screen.findByText(
+					"Your session will expire in 60 seconds. After that, you'll be redirected to the login page."
+				)
+			).toBeVisible();
+		});
+
+		it.each([60, 30])(
+			'should call logout when 60 seconds snackbar timeout expires (session lifetime is %s seconds)',
+			async (expirationSeconds) => {
+				const logoutFn = jest.spyOn(logout, 'logout').mockImplementation();
+				const expiration = expirationSeconds * 1000;
+				server.use(
+					http.post('/service/soap/GetInfoRequest', getGetInfoRequest({ lifetime: expiration }))
+				);
+				setup(<Loader />);
+				await act(async () => {
+					await jest.advanceTimersToNextTimerAsync();
+				});
+				await screen.findByText(
+					/Your session will expire in \d+ seconds\. After that, you'll be redirected to the login page\./i
+				);
+				await act(async () => {
+					await jest.advanceTimersByTimeAsync(expiration);
+				});
+				expect(logoutFn).toHaveBeenCalled();
+			}
+		);
+
+		it('should show 60 seconds snackbar and hide the 3 minutes snackbar', async () => {
+			const threeMinutes = 3 * 60 * 1000;
+			server.use(
+				http.post('/service/soap/GetInfoRequest', getGetInfoRequest({ lifetime: threeMinutes }))
+			);
+			setup(<Loader />);
+			await act(async () => {
+				await jest.advanceTimersToNextTimerAsync();
+			});
+			await screen.findByText(
+				"Your session will expire in 3 minutes. After that, you'll be redirected to the login page."
+			);
+			await act(async () => {
+				await jest.advanceTimersByTimeAsync(2 * 60 * 1000);
+			});
+			expect(
+				await screen.findByText(
+					"Your session will expire in 60 seconds. After that, you'll be redirected to the login page."
+				)
+			).toBeVisible();
+			expect(
+				screen.queryByText(
+					"Your session will expire in 3 minutes. After that, you'll be redirected to the login page."
+				)
+			).not.toBeInTheDocument();
+		});
+	});
 });

--- a/src/boot/loader.tsx
+++ b/src/boot/loader.tsx
@@ -6,7 +6,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { Modal, Padding, Text } from '@zextras/carbonio-design-system';
+import { Modal, Padding, Text, useSnackbar } from '@zextras/carbonio-design-system';
 import { find } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
@@ -16,6 +16,7 @@ import { IS_FOCUS_MODE } from '../constants';
 import { getComponents } from '../network/get-components';
 import { getInfo } from '../network/get-info';
 import { loginConfig } from '../network/login-config';
+import { logout } from '../network/logout';
 import { goToLogin } from '../network/utils';
 import { useAccountStore } from '../store/account';
 import { useAppStore } from '../store/app';
@@ -64,8 +65,19 @@ export const LoaderFailureModal = ({
 };
 
 export const Loader = (): React.JSX.Element => {
+	const [t] = useTranslation();
 	const [open, setOpen] = useState(false);
 	const closeHandler = useCallback(() => setOpen(false), []);
+	const [sessionLifetime, setSessionLifetime] = useState<number>();
+	const createSnackbar = useSnackbar();
+
+	const getSessionInfo = useCallback(
+		() =>
+			getInfo().then((sessionInfo) => {
+				setSessionLifetime(sessionInfo.lifetime);
+			}),
+		[]
+	);
 
 	const carbonioPrefSendAnalytics = useAccountStore(
 		(state) => state.settings.prefs.carbonioPrefSendAnalytics
@@ -78,7 +90,7 @@ export const Loader = (): React.JSX.Element => {
 	}, [carbonioPrefSendAnalytics, enableTracker]);
 
 	useEffect(() => {
-		Promise.allSettled([loginConfig(), getComponents(), getInfo()]).then(
+		Promise.allSettled([loginConfig(), getComponents(), getSessionInfo()]).then(
 			(promiseSettledResultArray) => {
 				const [, getComponentsPromiseSettledResult, getInfoPromiseSettledResult] =
 					promiseSettledResultArray;
@@ -105,6 +117,78 @@ export const Loader = (): React.JSX.Element => {
 		return () => {
 			unloadAllApps();
 		};
-	}, []);
+	}, [getSessionInfo]);
+
+	useEffect(() => {
+		const expirationTimeouts: NodeJS.Timeout[] = [];
+		const logoutFn = (): void => {
+			logout();
+		};
+		if (sessionLifetime !== undefined) {
+			const tenMinutes = 10 * 60 * 1000;
+			if (sessionLifetime >= tenMinutes) {
+				expirationTimeouts.push(
+					setTimeout(() => {
+						createSnackbar({
+							severity: 'info',
+							key: 'ten-minutes-from-expiration-snackbar',
+							autoHideTimeout: 10 * 1000,
+							label: t(
+								'snackbar.expiration.tenMinutes',
+								"Your session will expire in 10 minutes. After that, you'll be redirected to the login page."
+							),
+							actionLabel: t('snackbar.expiration.action', 'Go to login page'),
+							onActionClick: logoutFn
+						});
+					}, sessionLifetime - tenMinutes)
+				);
+			}
+
+			const threeMinutes = 3 * 60 * 1000;
+			if (sessionLifetime >= threeMinutes) {
+				expirationTimeouts.push(
+					setTimeout(() => {
+						createSnackbar({
+							severity: 'info',
+							key: 'three-minutes-from-expiration-snackbar',
+							disableAutoHide: true,
+							label: t(
+								'snackbar.expiration.threeMinutes',
+								"Your session will expire in 3 minutes. After that, you'll be redirected to the login page."
+							),
+							actionLabel: t('snackbar.expiration.action', 'Go to login page'),
+							onActionClick: logoutFn
+						});
+					}, sessionLifetime - threeMinutes)
+				);
+			}
+
+			const oneMinute = 60 * 1000;
+			expirationTimeouts.push(
+				setTimeout(() => {
+					createSnackbar({
+						severity: 'warning',
+						key: 'one-minute-from-expiration-snackbar',
+						autoHideTimeout: Math.min(oneMinute, sessionLifetime),
+						label: t(
+							'snackbar.expiration.threeMinutes',
+							"Your session will expire in 60 seconds. After that, you'll be redirected to the login page."
+						),
+						actionLabel: t('snackbar.expiration.action', 'Go to login page'),
+						onActionClick: logoutFn,
+						replace: true
+					});
+					expirationTimeouts.push(setTimeout(logoutFn, Math.min(oneMinute, sessionLifetime)));
+				}, sessionLifetime - oneMinute)
+			);
+		}
+
+		return (): void => {
+			expirationTimeouts.forEach((timeout) => {
+				clearTimeout(timeout);
+			});
+		};
+	}, [createSnackbar, sessionLifetime, t]);
+
 	return <LoaderFailureModal open={open} closeHandler={closeHandler} />;
 };

--- a/src/boot/loader.tsx
+++ b/src/boot/loader.tsx
@@ -172,7 +172,7 @@ export const Loader = (): React.JSX.Element => {
 							key: 'one-minute-from-expiration-snackbar',
 							autoHideTimeout: Math.min(oneMinute, sessionLifetime),
 							label: t(
-								'snackbar.expiration.threeMinutes',
+								'snackbar.expiration.oneMinute',
 								"Your session will expire in 60 seconds. After that, you'll be redirected to the login page."
 							),
 							actionLabel: t('snackbar.expiration.action', 'Go to login page'),

--- a/src/boot/loader.tsx
+++ b/src/boot/loader.tsx
@@ -165,21 +165,24 @@ export const Loader = (): React.JSX.Element => {
 
 			const oneMinute = 60 * 1000;
 			expirationTimeouts.push(
-				setTimeout(() => {
-					createSnackbar({
-						severity: 'warning',
-						key: 'one-minute-from-expiration-snackbar',
-						autoHideTimeout: Math.min(oneMinute, sessionLifetime),
-						label: t(
-							'snackbar.expiration.threeMinutes',
-							"Your session will expire in 60 seconds. After that, you'll be redirected to the login page."
-						),
-						actionLabel: t('snackbar.expiration.action', 'Go to login page'),
-						onActionClick: logoutFn,
-						replace: true
-					});
-					expirationTimeouts.push(setTimeout(logoutFn, Math.min(oneMinute, sessionLifetime)));
-				}, sessionLifetime - oneMinute)
+				setTimeout(
+					() => {
+						createSnackbar({
+							severity: 'warning',
+							key: 'one-minute-from-expiration-snackbar',
+							autoHideTimeout: Math.min(oneMinute, sessionLifetime),
+							label: t(
+								'snackbar.expiration.threeMinutes',
+								"Your session will expire in 60 seconds. After that, you'll be redirected to the login page."
+							),
+							actionLabel: t('snackbar.expiration.action', 'Go to login page'),
+							onActionClick: logoutFn,
+							replace: true
+						});
+						expirationTimeouts.push(setTimeout(logoutFn, Math.min(oneMinute, sessionLifetime)));
+					},
+					Math.max(sessionLifetime - oneMinute, 0)
+				)
 			);
 		}
 

--- a/src/mocks/handlers/getInfoRequest.ts
+++ b/src/mocks/handlers/getInfoRequest.ts
@@ -36,6 +36,7 @@ export const getGetInfoRequest =
 					signatures: { signature: [] },
 					rights: { targets: [] },
 					zimlets: { zimlet: [] },
+					lifetime: 86400000,
 					...getInfoResponse,
 					prefs: { _attrs: { ...LOGGED_USER.prefs, ...getInfoResponse?.prefs?._attrs } },
 					attrs: { _attrs: { ...LOGGED_USER.attrs, ...getInfoResponse?.attrs?._attrs } },

--- a/src/network/get-info.ts
+++ b/src/network/get-info.ts
@@ -12,11 +12,11 @@ import { useNetworkStore } from '../store/network';
 import { parsePollingInterval } from '../store/network/utils';
 import type { GetInfoResponse, SoapBody } from '../types/network';
 
-export const getInfo = (): Promise<void> =>
+export const getInfo = (): Promise<{ lifetime: number }> =>
 	getSoapFetch(SHELL_APP_ID)<SoapBody<{ rights: string }>, GetInfoResponse>('GetInfo', {
 		_jsns: JSNS.account,
 		rights: 'sendAs,sendAsDistList,viewFreeBusy,sendOnBehalfOf,sendOnBehalfOfDistList'
-	}).then((res: GetInfoResponse): void => {
+	}).then((res: GetInfoResponse) => {
 		if (res) {
 			const { account, settings, version } = normalizeAccount(res);
 			useNetworkStore.setState({
@@ -28,5 +28,8 @@ export const getInfo = (): Promise<void> =>
 				settings,
 				zimbraVersion: version
 			});
+
+			return { lifetime: res.lifetime };
 		}
+		return { lifetime: 0 };
 	});

--- a/src/shell/remove-modal-manager.test.tsx
+++ b/src/shell/remove-modal-manager.test.tsx
@@ -54,7 +54,5 @@ test('Using useModal hook without a ModalManager, log a Modal manager context no
 		});
 	});
 
-	expect(mockedError).toBeCalled();
-
-	expect(mockedError).toBeCalledWith('Modal manager context not initialized');
+	expect(mockedError).toHaveBeenCalledWith('Modal manager context not initialized');
 });

--- a/src/types/network/index.ts
+++ b/src/types/network/index.ts
@@ -65,6 +65,7 @@ export type GetInfoResponse = {
 	};
 	version: string;
 	rights: AccountRights;
+	lifetime: number;
 };
 
 export type PropsMods = Record<string, { app: string; value: unknown }>;


### PR DESCRIPTION
Show some snackbar to let know user the session is expiring soon. Once session is expired, redirect user to login page by performing a programmatic logout.

Refs: SHELL-207