### PR TITLE
feat!: remove deprecated implementation of addRoute

### DIFF
--- a/src/store/app/store.ts
+++ b/src/store/app/store.ts
@@ -219,10 +219,6 @@ export const useAppStore = create<AppState & AppActions>()((set, get) => ({
 						component: routeData.appView
 					});
 				}
-				// TODO remove with SHELL-212
-				if (routeData.app && state.apps[routeData.app] && routeData.focusMode !== true) {
-					state.apps[routeData.app].display = routeData.label;
-				}
 			})
 		);
 		return routeData.id;


### PR DESCRIPTION
BREAKING CHANGE: addRoute function is no more used to update app store display value
Refs: SHELL-212

- [x] https://github.com/zextras/carbonio-calendars-ui/pull/481 
- [x] https://github.com/zextras/carbonio-mails-ui/pull/641
- [x] https://github.com/zextras/carbonio-contacts-ui/pull/248
- [x] https://github.com/zextras/carbonio-ws-collaboration-ui/pull/353
- [x] https://github.com/zextras/carbonio-chats-ui/pull/49
- [x] https://github.com/zextras/carbonio-auth-ui/pull/95