### PR TITLE
fix: translate unit measures for size

### DIFF
--- a/src/settings/components/general-settings/user-quota.test.tsx
+++ b/src/settings/components/general-settings/user-quota.test.tsx
@@ -38,7 +38,7 @@ describe('User Quota', () => {
 			const quotaUsed = faker.number.int();
 			setupAccountStore(quotaUsed, quota);
 			setup(<UserQuota mobileView={false} />);
-			const quotaString = `${humanFileSize(quotaUsed)} of unlimited space`;
+			const quotaString = `${humanFileSize(quotaUsed, undefined)} of unlimited space`;
 			expect(screen.getByText(quotaString)).toBeVisible();
 		}
 	);
@@ -48,7 +48,7 @@ describe('User Quota', () => {
 		const quotaMax = 100;
 		setupAccountStore(quotaUsed, quotaMax);
 		setup(<UserQuota mobileView={false} />);
-		const quotaString = `${humanFileSize(quotaUsed)} of ${humanFileSize(quotaMax)} used`;
+		const quotaString = `${humanFileSize(quotaUsed, undefined)} of ${humanFileSize(quotaMax, undefined)} used`;
 		expect(screen.getByText(quotaString)).toBeVisible();
 	});
 

--- a/src/settings/components/general-settings/user-quota.tsx
+++ b/src/settings/components/general-settings/user-quota.tsx
@@ -42,15 +42,15 @@ const UserQuota: FC<UserQuotaProps> = ({ mobileView }) => {
 		if (quota < 0) {
 			return t('user_quota.unlimited', '{{used}} of unlimited space', {
 				replace: {
-					used: humanFileSize(used)
+					used: humanFileSize(used, t)
 				}
 			});
 		}
 		return t('user_quota.limited', {
 			defaultValue: '{{used}} of {{limit}} used',
 			replace: {
-				used: humanFileSize(used),
-				limit: humanFileSize(limit)
+				used: humanFileSize(used, t),
+				limit: humanFileSize(limit, t)
 			}
 		});
 	}, [limit, quota, t, used]);

--- a/src/settings/components/utils.test.ts
+++ b/src/settings/components/utils.test.ts
@@ -35,12 +35,12 @@ describe('genTimeToDate function', () => {
 
 describe('humanFileSize function', () => {
 	it('should return 0 B if input is 0', () => {
-		const result = humanFileSize(0);
+		const result = humanFileSize(0, undefined);
 		expect(result).toBe('0 B');
 	});
 
-	it('should return x if input is max safe integer', () => {
-		const result = humanFileSize(Number.MAX_SAFE_INTEGER);
+	it('should return 8.00 PB if input is max safe integer', () => {
+		const result = humanFileSize(Number.MAX_SAFE_INTEGER, undefined);
 		expect(result).toBe('8.00 PB');
 	});
 
@@ -55,7 +55,7 @@ describe('humanFileSize function', () => {
 		['ZB', 7],
 		['YB', 8]
 	])('should return %s unit if input pow is %s', (unit, pow) => {
-		const result = humanFileSize(1024 ** pow);
+		const result = humanFileSize(1024 ** pow, undefined);
 		expect(result).toBe(`1.00 ${unit}`);
 	});
 
@@ -71,13 +71,13 @@ describe('humanFileSize function', () => {
 	])(
 		'should return %s unit measure if input is one unit lower than the next unit measure',
 		(unit, pow) => {
-			const result = humanFileSize(1024 ** pow - 1024 ** (pow - 1));
+			const result = humanFileSize(1024 ** pow - 1024 ** (pow - 1), undefined);
 			expect(result).toBe(`1023.00 ${unit}`);
 		}
 	);
 
 	it('should change unit from KB to B when removing 1 B from 1024 B', () => {
-		expect(humanFileSize(1024 - 1)).toBe('1023.00 B');
+		expect(humanFileSize(1024 - 1, undefined)).toBe('1023.00 B');
 	});
 
 	it.each([
@@ -85,7 +85,7 @@ describe('humanFileSize function', () => {
 		['MB', 3],
 		['GB', 4]
 	])('should return 1024.00 %s if input is 1024 ** %s - 1', (unit, pow) => {
-		const result = humanFileSize(1024 ** pow - 1);
+		const result = humanFileSize(1024 ** pow - 1, undefined);
 		expect(result).toBe(`1024.00 ${unit}`);
 	});
 
@@ -95,11 +95,11 @@ describe('humanFileSize function', () => {
 		['ZB', 7],
 		['YB', 8]
 	])('should return %s unit if input pow is %s - 1B', (unit, pow) => {
-		const result = humanFileSize(1024 ** pow - 1);
+		const result = humanFileSize(1024 ** pow - 1, undefined);
 		expect(result).toBe(`1.00 ${unit}`);
 	});
 
 	it('should throw an error if inputSize is equal or greater than 1024 YB', () => {
-		expect(() => humanFileSize(1024 ** 9)).toThrow('Unsupported inputSize');
+		expect(() => humanFileSize(1024 ** 9, undefined)).toThrow('Unsupported inputSize');
 	});
 });

--- a/src/settings/components/utils.ts
+++ b/src/settings/components/utils.ts
@@ -572,14 +572,19 @@ export function calculateNewIdentitiesState(
 /**
  * Format a size in byte as human-readable
  */
-export const humanFileSize = (inputSize: number): string => {
+export const humanFileSize = (inputSize: number, t: TFunction | undefined): string => {
+	const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 	if (inputSize === 0) {
-		return '0 B';
+		const unit = units[0];
+		const translatedUnit = t ? t('size.unitMeasure', { context: unit, defaultValue: unit }) : unit;
+		return `0 ${translatedUnit}`;
 	}
 	const i = Math.floor(Math.log(inputSize) / Math.log(1024));
-	const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 	if (i >= units.length) {
 		throw new Error('Unsupported inputSize');
 	}
-	return `${(inputSize / 1024 ** i).toFixed(2).toString()} ${units[i]}`;
+	const unit = units[i];
+	const unitTranslated = t ? t('size.unitMeasure', { context: unit, defaultValue: unit }) : unit;
+	const size = (inputSize / 1024 ** i).toFixed(2).toString();
+	return `${size} ${unitTranslated}`;
 };


### PR DESCRIPTION
Refs: SHELL-236

---
Add translations:
- [x] "size.unitMeasure_B": "B"
- [x] "size.unitMeasure_KB": "KB"
- [x] "size.unitMeasure_MB": "MB"
- [x] "size.unitMeasure_GB": "GB"
- [x] "size.unitMeasure_TB": "TB"
- [x] "size.unitMeasure_PB": "PB"
- [x] "size.unitMeasure_EB": "EB"
- [x] "size.unitMeasure_ZB": "ZB"
- [x] "size.unitMeasure_YB": "YB"