### PR TITLE
fix: hide privacy and remove account subsections from settings

### DIFF
--- a/src/boot/app/default-views.test.tsx
+++ b/src/boot/app/default-views.test.tsx
@@ -1,0 +1,166 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { produce } from 'immer';
+
+import { DefaultViewsRegister } from './default-views';
+import { SEARCH_APP_ID, SETTINGS_APP_ID, SHELL_APP_ID } from '../../constants';
+import { useAccountStore } from '../../store/account';
+import { useAppStore } from '../../store/app';
+import { useLoginConfigStore } from '../../store/login/store';
+import { setup } from '../../tests/utils';
+import type { AccountSettingsAttrs } from '../../types/account';
+import type { AppRouteDescriptor, SettingsView } from '../../types/apps';
+
+describe('DefaultViews', () => {
+	it('should register search module', () => {
+		setup(<DefaultViewsRegister />);
+		expect(useAppStore.getState().routes).toMatchObject<Record<string, AppRouteDescriptor>>({
+			[SEARCH_APP_ID]: {
+				id: SEARCH_APP_ID,
+				app: SEARCH_APP_ID,
+				route: SEARCH_APP_ID,
+				label: 'Search',
+				position: 1000,
+				visible: true,
+				primaryBar: 'SearchModOutline',
+				badge: { show: false },
+				appView: expect.any(Function)
+			}
+		});
+	});
+
+	it.each<AccountSettingsAttrs['zimbraFeatureOptionsEnabled']>(['TRUE', undefined])(
+		'should register settings module if zimbraFeatureOptionsEnabled is %s',
+		(value) => {
+			useAccountStore.setState(
+				produce((state) => {
+					state.settings.attrs.zimbraFeatureOptionsEnabled = value;
+				})
+			);
+			setup(<DefaultViewsRegister />);
+			expect(useAppStore.getState().routes).toMatchObject<Record<string, AppRouteDescriptor>>({
+				[SETTINGS_APP_ID]: {
+					id: SETTINGS_APP_ID,
+					app: SETTINGS_APP_ID,
+					route: SETTINGS_APP_ID,
+					label: 'Settings',
+					position: 1100,
+					visible: true,
+					primaryBar: 'SettingsModOutline',
+					badge: { show: false },
+					appView: expect.any(Function),
+					secondaryBar: expect.any(Function)
+				}
+			});
+		}
+	);
+
+	it('should not register settings module if zimbraFeatureOptionsEnabled is FALSE', () => {
+		useAccountStore.setState(
+			produce((state) => {
+				state.settings.attrs.zimbraFeatureOptionsEnabled = 'FALSE';
+			})
+		);
+		setup(<DefaultViewsRegister />);
+		expect(Object.keys(useAppStore.getState().routes)).not.toContain(SETTINGS_APP_ID);
+	});
+
+	it('should test', () => {
+		expect([{ a: 'a' }, { a: 'b' }]).toContainEqual({ a: 'a' });
+	});
+
+	it('should register settings general view', () => {
+		useAccountStore.setState(
+			produce((state) => {
+				state.settings.attrs.zimbraFeatureOptionsEnabled = 'TRUE';
+			})
+		);
+		setup(<DefaultViewsRegister />);
+		expect(useAppStore.getState().views.settings).toContainEqual<SettingsView>({
+			id: 'general',
+			route: 'general',
+			app: SHELL_APP_ID,
+			component: expect.anything(),
+			icon: 'SettingsModOutline',
+			label: 'General Settings',
+			position: 1,
+			subSections: [
+				{ label: 'Appearance', id: 'appearance' },
+				{ label: 'Language', id: 'language' },
+				{ label: 'Out of Office Settings', id: 'out_of_office' },
+				{ label: 'Search', id: 'search_prefs' },
+				{ label: "User's quota", id: 'user_quota' }
+			]
+		});
+	});
+
+	it('should register privacy settings subsection if it is carbonio CE ', () => {
+		useAccountStore.setState(
+			produce((state) => {
+				state.settings.attrs.zimbraFeatureOptionsEnabled = 'TRUE';
+			})
+		);
+		useLoginConfigStore.setState({ isCarbonioCE: true });
+
+		setup(<DefaultViewsRegister />);
+		expect(useAppStore.getState().views.settings).toContainEqual(
+			expect.objectContaining<Pick<SettingsView, 'id' | 'subSections'>>({
+				id: 'general',
+				subSections: [
+					{ label: 'Appearance', id: 'appearance' },
+					{ label: 'Language', id: 'language' },
+					{ label: 'Out of Office Settings', id: 'out_of_office' },
+					{ label: 'Search', id: 'search_prefs' },
+					{ label: "User's quota", id: 'user_quota' },
+					{ label: 'Privacy', id: 'privacy-settings' }
+				]
+			})
+		);
+	});
+
+	it('should not register privacy settings subsection if it is not carbonio CE ', () => {
+		useAccountStore.setState(
+			produce((state) => {
+				state.settings.attrs.zimbraFeatureOptionsEnabled = 'TRUE';
+			})
+		);
+		useLoginConfigStore.setState({ isCarbonioCE: false });
+
+		setup(<DefaultViewsRegister />);
+		expect(useAppStore.getState().views.settings).toContainEqual(
+			expect.objectContaining<Pick<SettingsView, 'id' | 'subSections'>>({
+				id: 'general',
+				subSections: [
+					{ label: 'Appearance', id: 'appearance' },
+					{ label: 'Language', id: 'language' },
+					{ label: 'Out of Office Settings', id: 'out_of_office' },
+					{ label: 'Search', id: 'search_prefs' },
+					{ label: "User's quota", id: 'user_quota' }
+				]
+			})
+		);
+	});
+
+	it('should register settings accounts view', () => {
+		useAccountStore.setState(
+			produce((state) => {
+				state.settings.attrs.zimbraFeatureOptionsEnabled = 'TRUE';
+			})
+		);
+		setup(<DefaultViewsRegister />);
+		expect(useAppStore.getState().views.settings).toContainEqual<SettingsView>({
+			id: 'accounts',
+			route: 'accounts',
+			app: SHELL_APP_ID,
+			component: expect.any(Function),
+			icon: 'PersonOutline',
+			label: 'Accounts',
+			position: 1
+		});
+	});
+});

--- a/src/boot/app/default-views.test.tsx
+++ b/src/boot/app/default-views.test.tsx
@@ -70,10 +70,6 @@ describe('DefaultViews', () => {
 		expect(Object.keys(useAppStore.getState().routes)).not.toContain(SETTINGS_APP_ID);
 	});
 
-	it('should test', () => {
-		expect([{ a: 'a' }, { a: 'b' }]).toContainEqual({ a: 'a' });
-	});
-
 	it('should register settings general view', () => {
 		useAccountStore.setState(
 			produce((state) => {

--- a/src/boot/app/default-views.ts
+++ b/src/boot/app/default-views.ts
@@ -5,76 +5,120 @@
  */
 /* eslint-disable no-param-reassign */
 
-import type { TFunction } from 'i18next';
-import { size } from 'lodash';
+import { useEffect, useMemo } from 'react';
+
+import { useTranslation } from 'react-i18next';
 
 import { SEARCH_APP_ID, SETTINGS_APP_ID, SHELL_APP_ID } from '../../constants';
 import { SearchAppView } from '../../search/search-app-view';
 import { WrappedAccountsSettings } from '../../settings/accounts-settings';
 import GeneralSettings from '../../settings/general-settings';
-import { settingsSubSections } from '../../settings/general-settings-sub-sections';
+import { useSettingsSubSections } from '../../settings/general-settings-sub-sections';
 import { SettingsAppView } from '../../settings/settings-app-view';
 import { SettingsSidebar } from '../../settings/settings-sidebar';
 import { useAccountStore } from '../../store/account';
 import { useAppStore } from '../../store/app';
 import type { AppRouteDescriptor, SettingsView } from '../../types/apps';
 
-const settingsGeneralView = (t: TFunction): SettingsView => ({
-	id: 'general',
-	route: 'general',
-	app: SHELL_APP_ID,
-	component: GeneralSettings,
-	icon: 'SettingsModOutline',
-	label: t('settings.general.general', 'General Settings'),
-	position: 1,
-	subSections: settingsSubSections(t)
-});
+const useSearchModule = (): void => {
+	const [t] = useTranslation();
 
-const settingsAccountsView = (t: TFunction): SettingsView => ({
-	id: 'accounts',
-	route: 'accounts',
-	app: SHELL_APP_ID,
-	component: WrappedAccountsSettings,
-	icon: 'PersonOutline',
-	label: t('settings.accounts', 'Accounts'),
-	position: 1
-});
+	const searchRouteDescriptor = useMemo<AppRouteDescriptor>(
+		() => ({
+			id: SEARCH_APP_ID,
+			app: SEARCH_APP_ID,
+			route: SEARCH_APP_ID,
+			appView: SearchAppView,
+			badge: {
+				show: false
+			},
+			label: t('search.app', 'Search'),
+			position: 1000,
+			visible: true,
+			primaryBar: 'SearchModOutline'
+		}),
+		[t]
+	);
+	useEffect(() => {
+		useAppStore.getState().addRoute(searchRouteDescriptor);
 
-const searchRouteDescriptor = (t: TFunction): AppRouteDescriptor => ({
-	id: SEARCH_APP_ID,
-	app: SEARCH_APP_ID,
-	route: SEARCH_APP_ID,
-	appView: SearchAppView,
-	badge: {
-		show: false
-	},
-	label: t('search.app', 'Search'),
-	position: 1000,
-	visible: true,
-	primaryBar: 'SearchModOutline'
-});
+		return (): void => {
+			useAppStore.getState().removeRoute(searchRouteDescriptor.id);
+		};
+	}, [searchRouteDescriptor]);
+};
 
-const settingsRouteDescriptor = (t: TFunction): AppRouteDescriptor => ({
-	id: SETTINGS_APP_ID,
-	app: SETTINGS_APP_ID,
-	route: SETTINGS_APP_ID,
-	appView: SettingsAppView,
-	badge: {
-		show: false
-	},
-	label: t('settings.app', 'Settings'),
-	position: 1100,
-	visible: true,
-	primaryBar: 'SettingsModOutline',
-	secondaryBar: SettingsSidebar
-});
+const useSettingsModule = (): void => {
+	const [t] = useTranslation();
+	const settingsAttrs = useAccountStore((state) => state.settings.attrs);
+	const settingsSubSections = useSettingsSubSections();
 
-export const registerDefaultViews = (t: TFunction): void => {
-	const { attrs } = useAccountStore.getState().settings;
-	if (size(attrs) > 0 && attrs.zimbraFeatureOptionsEnabled !== 'FALSE') {
-		useAppStore.getState().addRoute(settingsRouteDescriptor(t));
-		useAppStore.getState().addSettingsView(settingsGeneralView(t));
-		useAppStore.getState().addSettingsView(settingsAccountsView(t));
-	}
-	useAppStore.getState().addRoute(searchRouteDescriptor(t));
+	const settingsGeneralView = useMemo<SettingsView>(
+		() => ({
+			id: 'general',
+			route: 'general',
+			app: SHELL_APP_ID,
+			component: GeneralSettings,
+			icon: 'SettingsModOutline',
+			label: t('settings.general.general', 'General Settings'),
+			position: 1,
+			subSections: settingsSubSections
+		}),
+		[settingsSubSections, t]
+	);
+
+	const settingsAccountView = useMemo<SettingsView>(
+		() => ({
+			id: 'accounts',
+			route: 'accounts',
+			app: SHELL_APP_ID,
+			component: WrappedAccountsSettings,
+			icon: 'PersonOutline',
+			label: t('settings.accounts', 'Accounts'),
+			position: 1
+		}),
+		[t]
+	);
+
+	const settingsRouteDescriptor = useMemo<AppRouteDescriptor>(
+		() => ({
+			id: SETTINGS_APP_ID,
+			app: SETTINGS_APP_ID,
+			route: SETTINGS_APP_ID,
+			appView: SettingsAppView,
+			badge: {
+				show: false
+			},
+			label: t('settings.app', 'Settings'),
+			position: 1100,
+			visible: true,
+			primaryBar: 'SettingsModOutline',
+			secondaryBar: SettingsSidebar
+		}),
+		[t]
+	);
+
+	useEffect(() => {
+		if (
+			Object.keys(settingsAttrs).length > 0 &&
+			settingsAttrs.zimbraFeatureOptionsEnabled !== 'FALSE'
+		) {
+			useAppStore.getState().addRoute(settingsRouteDescriptor);
+			useAppStore.getState().addSettingsView(settingsGeneralView);
+			useAppStore.getState().addSettingsView(settingsAccountView);
+		}
+
+		return (): void => {
+			useAppStore.getState().removeRoute(settingsRouteDescriptor.id);
+			useAppStore.getState().removeSettingsView(settingsGeneralView.id);
+			useAppStore.getState().removeSettingsView(settingsAccountView.id);
+		};
+	}, [settingsAccountView, settingsAttrs, settingsGeneralView, settingsRouteDescriptor, t]);
+};
+
+export const DefaultViewsRegister = (): null => {
+	useSearchModule();
+	useSettingsModule();
+
+	return null;
 };

--- a/src/boot/bootstrapper.tsx
+++ b/src/boot/bootstrapper.tsx
@@ -4,15 +4,13 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import type { FC } from 'react';
 import React, { useEffect } from 'react';
 
 import { SnackbarManager } from '@zextras/carbonio-design-system';
-import { useTranslation } from 'react-i18next';
 import { BrowserRouter, Route, Switch, useParams } from 'react-router-dom';
 
 import AppLoaderMounter from './app/app-loader-mounter';
-import { registerDefaultViews } from './app/default-views';
+import { DefaultViewsRegister } from './app/default-views';
 import { ContextBridge } from './context-bridge';
 import { Loader } from './loader';
 import { TrackerProvider } from './posthog';
@@ -31,15 +29,7 @@ const FocusModeListener = (): null => {
 	return null;
 };
 
-export const DefaultViewsRegister = (): null => {
-	const [t] = useTranslation();
-	useEffect(() => {
-		registerDefaultViews(t);
-	}, [t]);
-	return null;
-};
-
-const Bootstrapper: FC = () => (
+const Bootstrapper = (): React.JSX.Element => (
 	<TrackerProvider>
 		<ThemeProvider>
 			<ShellI18nextProvider>

--- a/src/settings/general-settings-sub-sections.ts
+++ b/src/settings/general-settings-sub-sections.ts
@@ -3,8 +3,12 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import type { TFunction } from 'i18next';
+import { useMemo } from 'react';
 
+import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
+
+import { useIsCarbonioCE } from '../store/login/hooks';
 import type { SettingsSubSection } from '../types/apps';
 
 export const appearanceSubSection = (t: TFunction): SettingsSubSection => ({
@@ -33,16 +37,23 @@ export const privacySubSection = (t: TFunction): SettingsSubSection => ({
 	id: 'privacy-settings'
 });
 
-export const accountSubSection = (t: TFunction): SettingsSubSection => ({
-	label: t('settings.general.account', 'Account'),
-	id: 'account'
-});
-export const settingsSubSections = (t: TFunction): Array<SettingsSubSection> => [
-	appearanceSubSection(t),
-	languageSubSection(t),
-	outOfOfficeSubSection(t),
-	searchPrefsSubSection(t),
-	quotaSubSection(t),
-	privacySubSection(t),
-	accountSubSection(t)
-];
+export const useSettingsSubSections = (): SettingsSubSection[] => {
+	const [t] = useTranslation();
+	const isCarbonioCE = useIsCarbonioCE();
+
+	return useMemo(() => {
+		const subSections = [
+			appearanceSubSection(t),
+			languageSubSection(t),
+			outOfOfficeSubSection(t),
+			searchPrefsSubSection(t),
+			quotaSubSection(t)
+		];
+
+		if (isCarbonioCE) {
+			subSections.push(privacySubSection(t));
+		}
+
+		return subSections;
+	}, [isCarbonioCE, t]);
+};

--- a/src/shell/shell-primary-bar.test.tsx
+++ b/src/shell/shell-primary-bar.test.tsx
@@ -12,7 +12,7 @@ import { Route, Switch, useParams, useRouteMatch } from 'react-router-dom';
 
 import AppViewContainer from './app-view-container';
 import ShellPrimaryBar from './shell-primary-bar';
-import { DefaultViewsRegister } from '../boot/bootstrapper';
+import { DefaultViewsRegister } from '../boot/app/default-views';
 import { usePushHistoryCallback } from '../history/hooks';
 import { ModuleSelector } from '../search/module-selector';
 import { useAccountStore } from '../store/account';


### PR DESCRIPTION
Hide privacy entry inside secondary bar following the same logic of the settings component.

Remove accounts subsection since it is not used anymore

Refs: SHELL-241