### PR TITLE
fix: update parsing of polling interval

### DIFF
--- a/src/network/fetch.test.ts
+++ b/src/network/fetch.test.ts
@@ -141,7 +141,7 @@ describe('Fetch', () => {
 			}
 		);
 
-		it.each<Duration>(['500', '500ms'])(
+		it.each<Duration>(['500', '500ms', '500s'])(
 			'should send limitToOneBlocked and wait if zimbraPrefMailPollingInterval is %s',
 			async (pollingPref) => {
 				useAccountStore.setState(
@@ -186,10 +186,10 @@ describe('Fetch', () => {
 			}
 		);
 
-		it('should not send limitToOneBlocked and wait if zimbraPrefMailPollingInterval is not 500ms', async () => {
+		it('should not send limitToOneBlocked and wait if zimbraPrefMailPollingInterval is not either 500, 500ms or 500s', async () => {
 			useAccountStore.setState(
 				produce<AccountState>((state) => {
-					state.settings.prefs.zimbraPrefMailPollingInterval = '500s';
+					state.settings.prefs.zimbraPrefMailPollingInterval = '60s';
 				})
 			);
 

--- a/src/store/network/utils.test.ts
+++ b/src/store/network/utils.test.ts
@@ -98,26 +98,72 @@ describe('Utils', () => {
 				expect(result).toBe(30000);
 			});
 
-			it('should return 500 if zimbraPrefMailPollingInterval is "500" without a duration unit', () => {
-				useNetworkStore.setState({ pollingInterval: 123456789 });
-				useAccountStore.setState((state) => ({
-					...state,
-					settings: {
-						...state.settings,
-						prefs: { ...state.settings.prefs, zimbraPrefMailPollingInterval: '500' }
-					}
-				}));
-				const response = {
-					Header: {
-						context: {}
-					},
-					Body: {}
-				} satisfies RawSoapResponse<Record<string, unknown>>;
-				const result = getPollingInterval(response);
-				expect(result).toBe(500);
+			describe('long polling cases', () => {
+				it('should return 500 if zimbraPrefMailPollingInterval is "500" without a duration unit', () => {
+					useNetworkStore.setState({ pollingInterval: 123456789 });
+					useAccountStore.setState((state) => ({
+						...state,
+						settings: {
+							...state.settings,
+							prefs: { ...state.settings.prefs, zimbraPrefMailPollingInterval: '500' }
+						}
+					}));
+					const response = {
+						Header: {
+							context: {}
+						},
+						Body: {}
+					} satisfies RawSoapResponse<Record<string, unknown>>;
+					const result = getPollingInterval(response);
+					expect(result).toBe(500);
+				});
+
+				it('should return 500 if zimbraPrefMailPollingInterval is "500ms"', () => {
+					useNetworkStore.setState({ pollingInterval: 123456789 });
+					useAccountStore.setState((state) => ({
+						...state,
+						settings: {
+							...state.settings,
+							prefs: {
+								...state.settings.prefs,
+								zimbraPrefMailPollingInterval: '500ms' satisfies Duration
+							}
+						}
+					}));
+					const response = {
+						Header: {
+							context: {}
+						},
+						Body: {}
+					} satisfies RawSoapResponse<Record<string, unknown>>;
+					const result = getPollingInterval(response);
+					expect(result).toBe(500);
+				});
+
+				it('should return 500 if zimbraPrefMailPollingInterval is "500s"', () => {
+					useNetworkStore.setState({ pollingInterval: 123456789 });
+					useAccountStore.setState((state) => ({
+						...state,
+						settings: {
+							...state.settings,
+							prefs: {
+								...state.settings.prefs,
+								zimbraPrefMailPollingInterval: '500s' satisfies Duration
+							}
+						}
+					}));
+					const response = {
+						Header: {
+							context: {}
+						},
+						Body: {}
+					} satisfies RawSoapResponse<Record<string, unknown>>;
+					const result = getPollingInterval(response);
+					expect(result).toBe(500);
+				});
 			});
 
-			it('should return the number if zimbraPrefMailPollingInterval is set without a duration unit', () => {
+			it('should return the number * 1000 if zimbraPrefMailPollingInterval is set without a duration unit(so are handled as seconds)', () => {
 				useNetworkStore.setState({ pollingInterval: 123456789 });
 				useAccountStore.setState((state) => ({
 					...state,
@@ -136,29 +182,7 @@ describe('Utils', () => {
 					Body: {}
 				} satisfies RawSoapResponse<Record<string, unknown>>;
 				const result = getPollingInterval(response);
-				expect(result).toBe(753);
-			});
-
-			it('should return the number * 60 * 1000 if zimbraPrefMailPollingInterval duration is set with the duration unit m (minutes)', () => {
-				useNetworkStore.setState({ pollingInterval: 123456789 });
-				useAccountStore.setState((state) => ({
-					...state,
-					settings: {
-						...state.settings,
-						prefs: {
-							...state.settings.prefs,
-							zimbraPrefMailPollingInterval: '50m' satisfies Duration
-						}
-					}
-				}));
-				const response = {
-					Header: {
-						context: {}
-					},
-					Body: {}
-				} satisfies RawSoapResponse<Record<string, unknown>>;
-				const result = getPollingInterval(response);
-				expect(result).toBe(50 * 60 * 1000);
+				expect(result).toBe(753_000);
 			});
 
 			it('should return the number if zimbraPrefMailPollingInterval is set with the duration unit ms (milliseconds)', () => {
@@ -203,6 +227,28 @@ describe('Utils', () => {
 				} satisfies RawSoapResponse<Record<string, unknown>>;
 				const result = getPollingInterval(response);
 				expect(result).toBe(753000);
+			});
+
+			it('should return the number * 60 * 1000 if zimbraPrefMailPollingInterval duration is set with the duration unit m (minutes)', () => {
+				useNetworkStore.setState({ pollingInterval: 123456789 });
+				useAccountStore.setState((state) => ({
+					...state,
+					settings: {
+						...state.settings,
+						prefs: {
+							...state.settings.prefs,
+							zimbraPrefMailPollingInterval: '50m' satisfies Duration
+						}
+					}
+				}));
+				const response = {
+					Header: {
+						context: {}
+					},
+					Body: {}
+				} satisfies RawSoapResponse<Record<string, unknown>>;
+				const result = getPollingInterval(response);
+				expect(result).toBe(50 * 60 * 1000);
 			});
 
 			it('should return the number * 60 * 60 * 1000 if zimbraPrefMailPollingInterval is set with the duration unit h (hours)', () => {

--- a/src/store/network/utils.ts
+++ b/src/store/network/utils.ts
@@ -29,6 +29,8 @@ const POLLING_RETRY_INTERVAL = 60_000;
 
 const POLLING_INVALID_DURATION = 30_000;
 
+const LONG_POLLING_MARKER_VALUE = 500;
+
 export const parsePollingInterval = (settings: AccountSettings): number => {
 	const pollingPref = settings.prefs?.zimbraPrefMailPollingInterval ?? '';
 	const [value, durationUnit] = pollingPref.split(/([a-z]+)/g);
@@ -36,10 +38,17 @@ export const parsePollingInterval = (settings: AccountSettings): number => {
 	if (Number.isNaN(pollingValue)) {
 		return POLLING_INVALID_DURATION;
 	}
+
+	if (
+		pollingValue === LONG_POLLING_MARKER_VALUE &&
+		(durationUnit === undefined || durationUnit === 'ms' || durationUnit === 's')
+	) {
+		return LONG_POLLING_MARKER_VALUE;
+	}
 	switch (durationUnit) {
-		case undefined:
 		case 'ms':
 			return pollingValue;
+		case undefined:
 		case 's':
 			return pollingValue * 1000;
 		case 'm':


### PR DESCRIPTION
value without UoM will be handled as seconds instead of milliseconds 500s will be used for long polling

Refs: SHELL-270 (#568)