### PR TITLE
build(deps): update zustand to 5.0.3 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"styled-components": "^6.1.13",
 				"tinymce": "^6.8.4",
 				"ua-parser-js": "^1.0.37",
-				"zustand": "^4.5.1"
+				"zustand": "^5.0.3"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.26.0",
@@ -5820,36 +5820,6 @@
 				"styled-components": "^6.1.13"
 			}
 		},
-		"node_modules/@zextras/carbonio-search-ui/node_modules/zustand": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.2.tgz",
-			"integrity": "sha512-8qNdnJVJlHlrKXi50LDqqUNmUbuBjoKLrYQBnoChIbVph7vni+sY+YpvdjXG9YLd/Bxr6scMcR+rm5H3aSqPaw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.20.0"
-			},
-			"peerDependencies": {
-				"@types/react": ">=18.0.0",
-				"immer": ">=9.0.6",
-				"react": ">=18.0.0",
-				"use-sync-external-store": ">=1.2.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"immer": {
-					"optional": true
-				},
-				"react": {
-					"optional": true
-				},
-				"use-sync-external-store": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@zextras/carbonio-shell-ui": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/@zextras/carbonio-shell-ui/-/carbonio-shell-ui-9.0.0.tgz",
@@ -6013,6 +5983,34 @@
 				"react": ">= 16.8.0",
 				"react-dom": ">= 16.8.0",
 				"react-is": ">= 16.8.0"
+			}
+		},
+		"node_modules/@zextras/carbonio-shell-ui/node_modules/zustand": {
+			"version": "4.5.6",
+			"resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.6.tgz",
+			"integrity": "sha512-ibr/n1hBzLLj5Y+yUcU7dYw8p6WnIVzdJbnX+1YpaScvZVF2ziugqHs+LAmHw4lWO9c/zRj+K1ncgWDQuthEdQ==",
+			"dev": true,
+			"dependencies": {
+				"use-sync-external-store": "^1.2.2"
+			},
+			"engines": {
+				"node": ">=12.7.0"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8",
+				"immer": ">=9.0.6",
+				"react": ">=16.8"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"immer": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-configs": {
@@ -19270,11 +19268,12 @@
 			}
 		},
 		"node_modules/use-sync-external-store": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+			"integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+			"devOptional": true,
 			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -20217,19 +20216,17 @@
 			}
 		},
 		"node_modules/zustand": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.1.tgz",
-			"integrity": "sha512-XlauQmH64xXSC1qGYNv00ODaQ3B+tNPoy22jv2diYiP4eoDKr9LA+Bh5Bc3gplTrFdb6JVI+N4kc1DZ/tbtfPg==",
-			"dependencies": {
-				"use-sync-external-store": "1.2.0"
-			},
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+			"integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
 			"engines": {
-				"node": ">=12.7.0"
+				"node": ">=12.20.0"
 			},
 			"peerDependencies": {
-				"@types/react": ">=16.8",
+				"@types/react": ">=18.0.0",
 				"immer": ">=9.0.6",
-				"react": ">=16.8"
+				"react": ">=18.0.0",
+				"use-sync-external-store": ">=1.2.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -20239,6 +20236,9 @@
 					"optional": true
 				},
 				"react": {
+					"optional": true
+				},
+				"use-sync-external-store": {
 					"optional": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
 		"styled-components": "^6.1.13",
 		"tinymce": "^6.8.4",
 		"ua-parser-js": "^1.0.37",
-		"zustand": "^4.5.1"
+		"zustand": "^5.0.3"
 	},
 	"peerDependencies": {
 		"@zextras/carbonio-design-system": "9.0.0-devel.13",

--- a/src/boot/use-get-primary-color.tsx
+++ b/src/boot/use-get-primary-color.tsx
@@ -6,6 +6,7 @@
 import { useEffect, useMemo } from 'react';
 
 import { size } from 'lodash';
+import { useShallow } from 'zustand/react/shallow';
 
 import { LOCAL_STORAGE_LAST_PRIMARY_KEY } from '../constants';
 import { useDarkMode } from '../dark-mode/use-dark-mode';
@@ -16,8 +17,14 @@ export function useGetPrimaryColor(): string | undefined {
 	const [localStorageLastPrimary, setLocalStorageLastPrimary] = useLocalStorage<
 		Partial<Record<'dark' | 'light', string>> | undefined
 	>(LOCAL_STORAGE_LAST_PRIMARY_KEY, undefined);
-	const { carbonioWebUiPrimaryColor, carbonioWebUiDarkPrimaryColor, loaded } =
-		useLoginConfigStore();
+	const { carbonioWebUiPrimaryColor, carbonioWebUiDarkPrimaryColor, loaded } = useLoginConfigStore(
+		useShallow((s) => ({
+			carbonioWebUiPrimaryColor: s.carbonioWebUiPrimaryColor,
+			carbonioWebUiDarkPrimaryColor: s.carbonioWebUiDarkPrimaryColor,
+			loaded: s.loaded
+		}))
+	);
+
 	const { darkModeEnabled, darkReaderStatus } = useDarkMode();
 
 	const primaryColor = useMemo(() => {

--- a/src/dark-mode/use-dark-reader-result-value.ts
+++ b/src/dark-mode/use-dark-reader-result-value.ts
@@ -38,7 +38,7 @@ export function isDarkReaderPropValues(
 // return the final calculated value between ZappDarkreaderModeZimletProp value and carbonioWebUiDarkMode config
 export function useDarkReaderResultValue(): undefined | DarkReaderPropValues {
 	const settings = useUserSettings();
-	const { carbonioWebUiDarkMode } = useLoginConfigStore();
+	const carbonioWebUiDarkMode = useLoginConfigStore((s) => s.carbonioWebUiDarkMode);
 
 	const settingReceived = useMemo(
 		() => size(settings.prefs) > 0 || size(settings.attrs) > 0 || size(settings.props) > 0,

--- a/src/shell/boards/board-container.tsx
+++ b/src/shell/boards/board-container.tsx
@@ -193,7 +193,7 @@ function calcPositionToRemainVisible(
 export const BoardContainer = (): React.JSX.Element | null => {
 	const t = getT();
 	const { boards, minimized, expanded, current, orderedBoards } = useBoardStore();
-	const { apps } = useAppStore();
+	const apps = useAppStore((s) => s.apps);
 
 	const boardDropdownItems = useMemo(
 		(): DropdownItem[] =>

--- a/src/shell/boards/board-tab-list.tsx
+++ b/src/shell/boards/board-tab-list.tsx
@@ -21,7 +21,8 @@ const CustomRow = styled(Row)`
 `;
 
 export const TabsList = (): React.JSX.Element => {
-	const { boards, orderedBoards } = useBoardStore();
+	const boards = useBoardStore((s) => s.boards);
+	const orderedBoards = useBoardStore((s) => s.orderedBoards);
 	return (
 		<CustomRow wrap="nowrap" height="100%" mainAlignment="flex-start" takeAvailableSpace>
 			{boards &&

--- a/src/shell/logo.tsx
+++ b/src/shell/logo.tsx
@@ -9,7 +9,7 @@ import { useLogo } from '../store/login/hooks';
 import { useLoginConfigStore } from '../store/login/store';
 
 export const Logo = (props: Record<string, unknown>): React.JSX.Element => {
-	const { loaded } = useLoginConfigStore();
+	const loaded = useLoginConfigStore((s) => s.loaded);
 	const LogoElement = useLogo();
 
 	return loaded ? (

--- a/src/shell/shell-primary-bar.tsx
+++ b/src/shell/shell-primary-bar.tsx
@@ -30,7 +30,8 @@ const PrimaryBarContainer = styled(Container)`
 `;
 
 const ToggleBoardIcon = (): React.JSX.Element | null => {
-	const { minimized, boards } = useBoardStore();
+	const minimized = useBoardStore((s) => s.minimized);
+	const boards = useBoardStore((s) => s.boards);
 
 	return isEmpty(boards) ? null : (
 		<Container width={'3rem'} height={'3rem'}>

--- a/src/store/account/hooks.ts
+++ b/src/store/account/hooks.ts
@@ -36,8 +36,10 @@ export const useUserAccounts = (): Array<Account> => {
 	return useMemo(() => (acct ? [acct] : []), [acct]);
 };
 
+const FALLBACK_ACCOUNT_RIGHTS = { targets: [] };
+
 export const useUserRights = (): AccountRights =>
-	useAccountStore((s) => s.account?.rights ?? { targets: [] });
+	useAccountStore((s) => s.account?.rights ?? FALLBACK_ACCOUNT_RIGHTS);
 
 export const useUserRight = (right: AccountRightName): Array<AccountRightTarget> => {
 	const { targets } = useUserRights();

--- a/src/store/login/hooks.ts
+++ b/src/store/login/hooks.ts
@@ -11,7 +11,8 @@ import DefaultLogo from '../../../assets/carbonio.svg';
 import { useDarkMode } from '../../dark-mode/use-dark-mode';
 
 export function useLogo(): string | React.ComponentType {
-	const { carbonioWebUiAppLogo, carbonioWebUiDarkAppLogo } = useLoginConfigStore();
+	const carbonioWebUiAppLogo = useLoginConfigStore((s) => s.carbonioWebUiAppLogo);
+	const carbonioWebUiDarkAppLogo = useLoginConfigStore((s) => s.carbonioWebUiDarkAppLogo);
 
 	const { darkModeEnabled } = useDarkMode();
 

--- a/src/store/network/hooks.ts
+++ b/src/store/network/hooks.ts
@@ -6,5 +6,7 @@
 import { useNetworkStore } from './store';
 import type { SoapNotify, SoapRefresh } from '../../types/network';
 
-export const useNotify = (): SoapNotify[] => useNetworkStore((s) => s.notify ?? []);
-export const useRefresh = (): SoapRefresh => useNetworkStore((s) => s.refresh ?? {});
+const FALLBACK_NOTIFY: SoapNotify[] = [];
+const FALLBACK_REFRESH: SoapRefresh = {};
+export const useNotify = (): SoapNotify[] => useNetworkStore((s) => s.notify ?? FALLBACK_NOTIFY);
+export const useRefresh = (): SoapRefresh => useNetworkStore((s) => s.refresh ?? FALLBACK_REFRESH);


### PR DESCRIPTION
Fixed BC about infinite loops if a selector returns a new reference (https://zustand.docs.pmnd.rs/migrations/migrating-to-v5#requiring-stable-selector-outputs).

Refactored some parts to improve store performances by replacing the extraction of values from a store through a selector function instead of using an object.
eg. selector function: `const apps = useAppStore((s) => s.apps)`
eg. object: `const { apps } = useAppStore()`
The reason is because using an object may cause unnecessary re-renders because the component updates whenever any extracted value changes.
Using a selector function improves performance because the component only re-renders when the value (apps) changes.
If you need to extract multiple values preventing re-renders we used `useShallow`.

Refs: SHELL-267