### PR TITLE
chore(store.ts): make setAppContext generic

### DIFF
--- a/api-extractor/carbonio-shell-ui.api.md
+++ b/api-extractor/carbonio-shell-ui.api.md
@@ -176,7 +176,7 @@ type AppActions = {
     removePrimaryAccessoryView: (id: string) => void;
     addSecondaryAccessoryView: (data: SecondaryAccessoryView) => string;
     removeSecondaryAccessoryView: (id: string) => void;
-    setAppContext: (app: string) => (context: unknown) => void;
+    setAppContext: (app: string) => <T = unknown>(context: T) => void;
 };
 
 // Warning: (ae-forgotten-export) The symbol "AppContextProviderProps" needs to be exported by the entry point lib.d.ts

--- a/src/store/app/store.ts
+++ b/src/store/app/store.ts
@@ -63,7 +63,7 @@ export type AppActions = {
 	removePrimaryAccessoryView: (id: string) => void;
 	addSecondaryAccessoryView: (data: SecondaryAccessoryView) => string;
 	removeSecondaryAccessoryView: (id: string) => void;
-	setAppContext: <T = unknown>(app: string) => (context: T) => void;
+	setAppContext: (app: string) => <T = unknown>(context: T) => void;
 };
 
 const FOCUS_MODE_RESPONSE = 'focus-mode';

--- a/src/store/app/store.ts
+++ b/src/store/app/store.ts
@@ -63,7 +63,7 @@ export type AppActions = {
 	removePrimaryAccessoryView: (id: string) => void;
 	addSecondaryAccessoryView: (data: SecondaryAccessoryView) => string;
 	removeSecondaryAccessoryView: (id: string) => void;
-	setAppContext: (app: string) => (context: unknown) => void;
+	setAppContext: <T = unknown>(app: string) => (context: T) => void;
 };
 
 const FOCUS_MODE_RESPONSE = 'focus-mode';


### PR DESCRIPTION
Changed the setAppContext action to use a generic type parameter for context
instead of always defaulting to unknown. This allows specifying the context
type when calling setAppContext.