### PR TITLE
feat: display the total quota usage on the header

### DIFF
--- a/src/shell/shell-header.test.tsx
+++ b/src/shell/shell-header.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import ShellHeader from './shell-header';
+import { useIntegrationsStore } from '../store/integrations/store';
+import { setup, screen } from '../tests/utils';
+
+describe('ShellHeader', () => {
+	it('should render ShellHeader component', () => {
+		setup(
+			<ShellHeader>
+				<></>
+			</ShellHeader>
+		);
+		const headerElement = screen.getByTestId('MainHeaderContainer');
+		expect(headerElement).toBeInTheDocument();
+	});
+
+	it('should render children correctly', () => {
+		setup(
+			<ShellHeader>
+				<div data-testid="ChildElement">Child Content</div>
+			</ShellHeader>
+		);
+		const childElement = screen.getByTestId('ChildElement');
+		expect(childElement).toBeInTheDocument();
+		expect(childElement).toHaveTextContent('Child Content');
+	});
+
+	it('should render the total quota component if available', () => {
+		useIntegrationsStore.setState(
+			(state) => ({
+				...state,
+				components: {
+					'total-quota-usage': {
+						app: 'test-app',
+						Item: jest.fn()
+					}
+				}
+			}),
+			true
+		);
+
+		setup(<ShellHeader>{null}</ShellHeader>);
+
+		expect(screen.getByTestId('TotalQuotaUsageContainer')).toBeVisible();
+	});
+
+	it('should not render the total quota component if not available', () => {
+		setup(<ShellHeader>{null}</ShellHeader>);
+
+		expect(screen.queryByTestId('TotalQuotaUsageContainer')).not.toBeInTheDocument();
+	});
+});

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -33,6 +33,8 @@ const ShellHeader = ({ children }: ShellHeaderProps): React.JSX.Element => {
 
 	const [SearchBar, isSearchBarAvailable] =
 		useIntegratedComponent<typeof SearchUISearchBar>('search-bar');
+
+	const [TotalQuotaUsage, isTotalQuotaUsageAvailable] = useIntegratedComponent('total-quota-usage');
 	return (
 		<ShellHeaderContainer
 			data-testid="MainHeaderContainer"
@@ -61,7 +63,24 @@ const ShellHeader = ({ children }: ShellHeaderProps): React.JSX.Element => {
 					<Padding horizontal="large">
 						<CreationButton />
 					</Padding>
-					{isSearchBarAvailable && <SearchBar />}
+					{isSearchBarAvailable && (
+						<Catcher>
+							<SearchBar />
+						</Catcher>
+					)}
+					{isTotalQuotaUsageAvailable && (
+						<Container
+							data-testid="TotalQuotaUsageContainer"
+							maxWidth="13.8125rem"
+							height={'3.125rem'}
+							borderColor={{ left: 'gray2' }}
+							padding={{ horizontal: 'large', vertical: 'small' }}
+						>
+							<Catcher>
+								<TotalQuotaUsage />
+							</Catcher>
+						</Container>
+					)}
 				</Container>
 				<Container
 					orientation="horizontal"


### PR DESCRIPTION
Add a slot on the header component to display (if available) a component that inform the user about the current quota usage

Refs: CO-3060