### PR TITLE
feat(login): add featureFlags support and hide quota section when totalQuota flag is enabled

### DIFF
--- a/api-extractor/carbonio-shell-ui.api.md
+++ b/api-extractor/carbonio-shell-ui.api.md
@@ -433,6 +433,11 @@ type Exactify<T, X extends T> = T & {
 export const expandBoards: () => void;
 
 // @public (undocumented)
+export type FeatureFlags = {
+    totalQuota?: boolean;
+};
+
+// @public (undocumented)
 type FolderView = 'search folder' | 'tag' | 'conversation' | 'message' | 'contact' | 'document' | 'appointment' | 'virtual conversation' | 'remote folder' | 'wiki' | 'task' | 'chat';
 
 // @public (undocumented)
@@ -1161,6 +1166,9 @@ export const useBoardHooks: () => BoardHooksContext;
 //
 // @public (undocumented)
 export const useCurrentRoute: () => AppRoute | undefined;
+
+// @public
+export function useFeatureFlag<K extends keyof FeatureFlags>(key: K): boolean | undefined;
 
 // @public (undocumented)
 export const useIntegratedComponent: <TComponent extends React_2.ComponentType<any> = React_2.ComponentType<Record<string, unknown>>>(id: string) => [TComponent, boolean];

--- a/src/boot/app/app-direct-exports.ts
+++ b/src/boot/app/app-direct-exports.ts
@@ -91,7 +91,7 @@ export const {
 	upsertApp
 } = useAppStore.getState();
 
-export { useIsCarbonioCE } from '../../store/login/hooks';
+export { useIsCarbonioCE, useFeatureFlag } from '../../store/login/hooks';
 
 export type { NewAction } from '../../shell/creation-button';
 export type { AccountMenuAction } from '../../utility-bar/bar';

--- a/src/boot/app/app-direct-exports.ts
+++ b/src/boot/app/app-direct-exports.ts
@@ -92,6 +92,7 @@ export const {
 } = useAppStore.getState();
 
 export { useIsCarbonioCE, useFeatureFlag } from '../../store/login/hooks';
+export type { FeatureFlags } from '../../store/login/store';
 
 export type { NewAction } from '../../shell/creation-button';
 export type { AccountMenuAction } from '../../utility-bar/bar';

--- a/src/settings/general-settings-sub-sections.ts
+++ b/src/settings/general-settings-sub-sections.ts
@@ -8,7 +8,7 @@ import { useMemo } from 'react';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 
-import { useIsCarbonioCE } from '../store/login/hooks';
+import { useFeatureFlag, useIsCarbonioCE } from '../store/login/hooks';
 import type { SettingsSubSection } from '../types/apps';
 
 export const appearanceSubSection = (t: TFunction): SettingsSubSection => ({
@@ -40,20 +40,24 @@ export const privacySubSection = (t: TFunction): SettingsSubSection => ({
 export const useSettingsSubSections = (): SettingsSubSection[] => {
 	const [t] = useTranslation();
 	const isCarbonioCE = useIsCarbonioCE();
+	const totalQuotaEnabled = useFeatureFlag('totalQuota');
 
 	return useMemo(() => {
 		const subSections = [
 			appearanceSubSection(t),
 			languageSubSection(t),
 			outOfOfficeSubSection(t),
-			searchPrefsSubSection(t),
-			quotaSubSection(t)
+			searchPrefsSubSection(t)
 		];
+
+		if (!totalQuotaEnabled) {
+			subSections.push(quotaSubSection(t));
+		}
 
 		if (isCarbonioCE) {
 			subSections.push(privacySubSection(t));
 		}
 
 		return subSections;
-	}, [isCarbonioCE, t]);
+	}, [isCarbonioCE, t, totalQuotaEnabled]);
 };

--- a/src/settings/general-settings.tsx
+++ b/src/settings/general-settings.tsx
@@ -26,7 +26,7 @@ import { useLocalStorage } from '../shell/hooks/useLocalStorage';
 import { useAccountStore, useUserSettings } from '../store/account';
 import { mergePrefs, mergeProps } from '../store/account/utils';
 import { getT } from '../store/i18n/hooks';
-import { useIsCarbonioCE } from '../store/login/hooks';
+import { useFeatureFlag, useIsCarbonioCE } from '../store/login/hooks';
 import type { AccountState } from '../types/account';
 import type {
 	AddMod,
@@ -56,6 +56,7 @@ const GeneralSettings = (): React.JSX.Element => {
 	);
 	const [open, setOpen] = useState(false);
 	const isCarbonioCE = useIsCarbonioCE();
+	const totalQuotaEnabled = useFeatureFlag('totalQuota');
 
 	const addLocalStoreChange = useCallback(
 		(key: keyof ScalingSettings, value: ValueOf<ScalingSettings>) => {
@@ -283,7 +284,7 @@ const GeneralSettings = (): React.JSX.Element => {
 					addMod={addMod}
 					resetRef={searchSettingsSectionRef}
 				/>
-				<UserQuota mobileView={false} />
+				{!totalQuotaEnabled && <UserQuota mobileView={false} />}
 				{isCarbonioCE && (
 					<SettingsSection {...privacySubSection(t)}>
 						<Privacy

--- a/src/store/login/hooks.ts
+++ b/src/store/login/hooks.ts
@@ -6,6 +6,7 @@
 import type React from 'react';
 import { useMemo } from 'react';
 
+import type { FeatureFlags } from './store';
 import { useLoginConfigStore } from './store';
 import DefaultLogo from '../../../assets/carbonio.svg';
 import { useDarkMode } from '../../dark-mode/use-dark-mode';
@@ -29,4 +30,11 @@ export function useLogo(): string | React.ComponentType {
  */
 export function useIsCarbonioCE(): boolean | undefined {
 	return useLoginConfigStore((state) => state.isCarbonioCE);
+}
+
+/**
+ * Hook useful to read a specific feature flag value
+ */
+export function useFeatureFlag<K extends keyof FeatureFlags>(key: K): boolean | undefined {
+	return useLoginConfigStore((state) => state.featureFlags?.[key]);
 }

--- a/src/store/login/store.ts
+++ b/src/store/login/store.ts
@@ -6,6 +6,10 @@
 
 import { create } from 'zustand';
 
+export type FeatureFlags = {
+	totalQuota?: boolean;
+};
+
 export type LoginConfigStore = {
 	carbonioWebUiDarkMode?: boolean;
 	carbonioWebUiAppLogo?: string;
@@ -17,6 +21,7 @@ export type LoginConfigStore = {
 	carbonioWebUiLogoutURL?: string;
 	loaded: boolean;
 	isCarbonioCE: boolean | undefined;
+	featureFlags?: FeatureFlags;
 };
 
 // extra currying as suggested in https://github.com/pmndrs/zustand/blob/main/docs/guides/typescript.md#basic-usage


### PR DESCRIPTION
## Summary

- Add `FeatureFlags` type and `featureFlags` field to `LoginConfigStore`
- Add `useFeatureFlag` hook to read specific feature flags
- Expose `useFeatureFlag` in app-direct-exports
- Hide User's quota section in General Settings when `totalQuota` flag is `true`
- Remove quota sub-section from settings navigation when `totalQuota` flag is `true`

## Test plan

- [ ] Verify quota section is hidden in General Settings when `totalQuota` feature flag is enabled
- [ ] Verify quota section is visible when `totalQuota` feature flag is disabled or absent
- [ ] Verify `useFeatureFlag` hook returns correct value for a given flag
- [ ] Verify `FeatureFlags` type is exported correctly from the public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)