### PR TITLE
chore(deps): bump @fontsource/roboto from 5.0.8 to 5.2.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@emotion/react": "^11.14.0",
 				"@emotion/styled": "^11.14.1",
-				"@fontsource/roboto": "^5.0.8",
+				"@fontsource/roboto": "^5.2.10",
 				"@zextras/carbonio-design-system": "12.0.2",
 				"@zextras/carbonio-ui-preview": "4.0.2",
 				"@zextras/carbonio-ui-soap-lib": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
 	"dependencies": {
 		"@emotion/react": "^11.14.0",
 		"@emotion/styled": "^11.14.1",
-		"@fontsource/roboto": "^5.0.8",
+		"@fontsource/roboto": "^5.2.10",
 		"@zextras/carbonio-design-system": "12.0.2",
 		"@zextras/carbonio-ui-preview": "4.0.2",
 		"@zextras/carbonio-ui-soap-lib": "1.0.4",


### PR DESCRIPTION
## Bump `@fontsource/roboto` from `5.0.8` to `5.2.10`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `^5.0.8`
- **New:** `^5.2.10`
- **Minor jump:** +2
- **Repository:** https://github.com/fontsource/font-files/tree/main/fonts/google/roboto
- **npm:** https://www.npmjs.com/package/@fontsource/roboto/v/5.2.10

### Changelog

> No GitHub releases retrievable for [fontsource/font-files](https://github.com/fontsource/font-files).
> See the [releases page](https://github.com/fontsource/font-files/releases) or the [npm page](https://www.npmjs.com/package/@fontsource/roboto/v/5.2.10).

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter @fontsource/roboto && npm install`
- Only `package.json` and `package-lock.json` were modified.

🤖 Generated by the `update-deps` skill.
