### PR TITLE
chore(deps): bump @zextras/carbonio-ui-soap-lib from 1.0.4 to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@fontsource/roboto": "^5.0.8",
 				"@zextras/carbonio-design-system": "12.0.2",
 				"@zextras/carbonio-ui-preview": "4.0.2",
-				"@zextras/carbonio-ui-soap-lib": "1.0.4",
+				"@zextras/carbonio-ui-soap-lib": "1.1.0",
 				"darkreader": "4.9.120",
 				"date-fns": "^4.1.0",
 				"i18next": "^22.5.1",
@@ -7249,6 +7249,17 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@zextras/carbonio-shell-ui/node_modules/@zextras/carbonio-ui-soap-lib": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-soap-lib/-/carbonio-ui-soap-lib-1.0.4.tgz",
+			"integrity": "sha512-vRaizwsMPC4fODiBXiNwVnKH9b9IlKWNhAu3uYzb+BvB+HMTzxb6OGLtgLqgW+PVvBb56x+ITIbdONBsVV69OQ==",
+			"dev": true,
+			"license": "AGPL-3.0-only",
+			"dependencies": {
+				"@types/ua-parser-js": "^0.7.39",
+				"ua-parser-js": "^1.0.37"
+			}
+		},
 		"node_modules/@zextras/carbonio-ui-configs": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-configs/-/carbonio-ui-configs-2.1.0.tgz",
@@ -7469,13 +7480,13 @@
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-soap-lib": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-soap-lib/-/carbonio-ui-soap-lib-1.0.4.tgz",
-			"integrity": "sha512-vRaizwsMPC4fODiBXiNwVnKH9b9IlKWNhAu3uYzb+BvB+HMTzxb6OGLtgLqgW+PVvBb56x+ITIbdONBsVV69OQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-soap-lib/-/carbonio-ui-soap-lib-1.1.0.tgz",
+			"integrity": "sha512-i11CNTX6dQSjmWo7B/oDihvUdiNuB793rNZU37AxfbW3BkeutWA4FVXuGKHVxge1QEvrRtYOwGs8HKvrhQyAsw==",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
-				"@types/ua-parser-js": "^0.7.39",
-				"ua-parser-js": "^1.0.37"
+				"@types/ua-parser-js": "0.7.39",
+				"ua-parser-js": "1.0.41"
 			}
 		},
 		"node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
 		"@fontsource/roboto": "^5.0.8",
 		"@zextras/carbonio-design-system": "12.0.2",
 		"@zextras/carbonio-ui-preview": "4.0.2",
-		"@zextras/carbonio-ui-soap-lib": "1.0.4",
+		"@zextras/carbonio-ui-soap-lib": "1.1.0",
 		"darkreader": "4.9.120",
 		"date-fns": "^4.1.0",
 		"i18next": "^22.5.1",


### PR DESCRIPTION
## Bump `@zextras/carbonio-ui-soap-lib` from `1.0.4` to `1.1.0`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `1.0.4`
- **New:** `1.1.0`
- **Minor jump:** +1
- **npm:** https://www.npmjs.com/package/@zextras/carbonio-ui-soap-lib/v/1.1.0

### Changelog


#### [`v1.1.0`](https://github.com/zextras/carbonio-ui-soap-lib/releases/tag/v1.1.0)

## 1.1.0 (2026-04-09)

* fix: add deps for release (#64) ([86ce2ff](https://github.com/zextras/carbonio-ui-soap-lib/commit/86ce2ff)), closes [#64](https://github.com/zextras/carbonio-ui-soap-lib/issues/64)
* fix(deps): update dependency ua-parser-js to ^1.0.41 (#26) ([ab6ddf7](https://github.com/zextras/carbonio-ui-soap-lib/commit/ab6ddf7)), closes [#26](https://github.com/zextras/carbonio-ui-soap-lib/issues/26)
* fix(deps): upgrade node to v22 ([6c439aa](https://github.com/zextras/carbonio-ui-soap-lib/commit/6c439aa))
* feat: migrate from npm to pnpm (#63) ([85a583a](https://github.com/zextras/carbonio-ui-soap-lib/commit/85a583a)), closes [#63](https://github.com/zextras/carbonio-ui-soap-lib/issues/63)
* chore: add renovate configuration (#22) ([2c05f03](https://github.com/zextras/carbonio-ui-soap-lib/commit/2c05f03)), closes [#22](https://github.com/zextras/carbonio-ui-soap-lib/issues/22)
* chore(ci): move to kube agents ([8abce05](https://github.com/zextras/carbonio-ui-soap-lib/commit/8abce05))
* chore(ci): update GitHub credentials for Jenkins integration ([432c0e7](https://github.com/zextras/carbonio-ui-soap-lib/commit/432c0e7))
* chore(deps): lock file maintenance (#28) ([8a7539e](https://github.com/zextras/carbonio-ui-soap-lib/commit/8a7539e)), closes [#28](https://github.com/zextras/carbonio-ui-soap-lib/issues/28)
* chore(deps): lock file maintenance (#29) ([48e7034](https://github.com/zextras/carbonio-ui-soap-lib/commit/48e7034)), closes [#29](https://github.com/zextras/carbonio-ui-soap-lib/issues/29)
* chore(deps): lock file maintenance (#32) ([7a00391](https://github.com/zextras/carbonio-ui-soap-lib/commit/7a00391)), closes [#32](https://github.com/zextras/carbonio-ui-soap-lib/issues/32)
* chore(deps): lock file maintenance (#35) ([53a3b7e](https://github.com/zextras/carbonio-ui-soap-lib/commit/53a3b7e)), closes [#35](https://github.com/zextras/carbonio-ui-soap-lib/issues/35)
* chore(deps): lock file maintenance (#36) ([e5064b7](https://github.com/zextras/carbonio-ui-soap-lib/commit/e5064b7)), closes [#36](https://github.com/zextras/carbonio-ui-soap-lib/issues/36)
* chore(deps): lock file maintenance (#38) ([47f9064](https://github.com/zextras/carbonio-ui-soap-lib/commit/47f9064)), closes [#38](https://github.com/zextras/carbonio-ui-soap-lib/issues/38)
* chore(deps): lock file maintenance (#39) ([26f4a82](https://github.com/zextras/carbonio-ui-soap-lib/commit/26f4a82)), closes [#39](https://github.com/zextras/carbonio-ui-soap-lib/issues/39)
* chore(deps): lock file maintenance (#40) ([4f6d0db](https://github.com/zextras/carbonio-ui-soap-lib/commit/4f6d0db)), closes [#40](https://github.com/zextras/carbonio-ui-soap-lib/issues/40)
* chore(deps): lock file maintenance (#41) ([86e0772](https://github.com/zextras/carbonio-ui-soap-lib/commit/86e0772)), closes [#41](https://github.com/zextras/carbonio-ui-soap-lib/issues/41)
* chore(deps): lock file maintenance (#42) ([825605a](https://github.com/zextras/carbonio-ui-soap-lib/commit/825605a)), closes [#42](https://github.com/zextras/carbonio-ui-soap-lib/issues/42)
* chore(deps): lock file maintenance (#47) ([b77df2f](https://github.com/zextras/carbonio-ui-soap-lib/commit/b77df2f)), closes [#47](https://github.com/zextras/carbonio-ui-soap-lib/issues/47)
* chore(deps): lock file maintenance (#48) ([7aa625a](https://github.com/zextras/carbonio-ui-soap-lib/commit/7aa625a)), closes [#48](https://github.com/zextras/carbonio-ui-soap-lib/issues/48)
* chore(deps): lock file maintenance (#51) ([c981834](https://github.com/zextras/carbonio-ui-soap-lib/commit/c981834)), closes [#51](https://github.com/zextras/carbonio-ui-soap-lib/issues/51)
* chore(deps): lock file maintenance (#52) ([ee9b206](https://github.com/zextras/carbonio-ui-soap-lib/commit/ee9b206)), closes [#52](https://github.com/zextras/carbonio-ui-soap-lib/issues/52)
* chore(deps): lock file maintenance (#55) ([0ed378e](https://github.com/zextras/carbonio-ui-soap-lib/commit/0ed378e)), closes [#55](https://github.com/zextras/carbonio-ui-soap-lib/issues/55)
* chore(deps): lock file maintenance (#56) ([0d91e68](https://github.com/zextras/carbonio-ui-soap-lib/commit/0d91e68)), closes [#56](https://github.com/zextras/carbonio-ui-soap-lib/issues/56)
* chore(deps): lock file maintenance (#61) ([28c4917](https://github.com/zextras/carbonio-ui-soap-lib/commit/28c4917)), closes [#61](https://github.com/zextras/carbonio-ui-soap-lib/issues/61)
* chore(deps): lock file maintenance (#62) ([0fec3a5](https://github.com/zextras/carbonio-ui-soap-lib/commit/0fec3a5)), closes [#62](https://github.com/zextras/carbonio-ui-soap-lib/issues/62)
* chore(deps): update babel to ^7.28.5 (#27) ([6d77ff7](https://github.com/zextras/carbonio-ui-soap-lib/commit/6d77ff7)), closes [#27](https://github.com/zextras/carbonio-ui-soap-lib/issues/27)
* chore(deps): update babel to ^7.29.0 (#43) ([68c1f5a](https://github.com/zextras/carbonio-ui-soap-lib/commit/68c1f5a)), closes [#43](https://github.com/zextras/carbonio-ui-soap-lib/issues/43)
* chore(deps): update commitlint to ^19.8.1 (#24) ([83d77bd](https://github.com/zextras/carbonio-ui-soap-lib/commit/83d77bd)), closes [#24](https://github.com/zextras/carbonio-ui-soap-lib/issues/24)
* chore(deps): update dependency @babel/preset-env to ^7.29.2 (#57) ([e4fe716](https://github.com/zextras/carbonio-ui-soap-lib/commit/e4fe716)), closes [#57](https://github.com/zextras/carbonio-ui-soap-lib/issues/57)
* chore(deps): update dependency @faker-js/faker to ^9.9.0 (#33) ([6614cf4](https://github.com/zextras/carbonio-ui-soap-lib/commit/6614cf4)), closes [#33](https://github.com/zextras/carbonio-ui-soap-lib/issues/33)
* chore(deps): update dependency @testing-library/react to v16.3.2 (#53) ([59b00c6](https://github.com/zextras/carbonio-ui-soap-lib/commit/59b00c6)), closes [#53](https://github.com/zextras/carbonio-ui-soap-lib/issues/53)
* chore(deps): update dependency @types/react to ^18.3.28 (#44) ([cb06f8f](https://github.com/zextras/carbonio-ui-soap-lib/commit/cb06f8f)), closes [#44](https://github.com/zextras/carbonio-ui-soap-lib/issues/44)
* chore(deps): update dependency jsdom to ^26.1.0 (#34) ([39a21d1](https://github.com/zextras/carbonio-ui-soap-lib/commit/39a21d1)), closes [#34](https://github.com/zextras/carbonio-ui-soap-lib/issues/34)
* chore(deps): update dependency msw to ^2.12.10 (#45) ([912fa74](https://github.com/zextras/carbonio-ui-soap-lib/commit/912fa74)), closes [#45](https://github.com/zextras/carbonio-ui-soap-lib/issues/45)
* chore(deps): update dependency msw to ^2.12.14 (#58) ([81c6fe2](https://github.com/zextras/carbonio-ui-soap-lib/commit/81c6fe2)), closes [#58](https://github.com/zextras/carbonio-ui-soap-lib/issues/58)
* chore(deps): update dependency rollup to ^4.60.0 (#59) ([8a54081](https://github.com/zextras/carbonio-ui-soap-lib/commit/8a54081)), closes [#59](https://github.com/zextras/carbonio-ui-soap-lib/issues/59)
* chore(deps): update dependency typescript to ^5.9.3 (#46) ([ab084da](https://github.com/zextras/carbonio-ui-soap-lib/commit/ab084da)), closes [#46](https://github.com/zextras/carbonio-ui-soap-lib/issues/46)
* chore(deps): update react (#25) ([43e31ee](https://github.com/zextras/carbonio-ui-soap-lib/commit/43e31ee)), closes [#25](https://github.com/zextras/carbonio-ui-soap-lib/issues/25)
* chore(deps): update rollup (#49) ([fdd5804](https://github.com/zextras/carbonio-ui-soap-lib/commit/fdd5804)), closes [#49](https://github.com/zextras/carbonio-ui-soap-lib/issues/49)
* chore(deps): update vitest to ^3.2.4 (#50) ([547275c](https://github.com/zextras/carbonio-ui-soap-lib/commit/547275c)), closes [#50](https://github.com/zextras/carbonio-ui-soap-lib/issues/50)
* chore(release): v1.0.3 ([43500dd](https://github.com/zextras/carbonio-ui-soap-lib/commit/43500dd))
* docs: add thirdparties and fix license (#37) ([7cc4e9b](https://github.com/zextras/carbonio-ui-soap-lib/commit/7cc4e9b)), closes [#37](https://github.com/zextras/carbonio-ui-soap-lib/issues/37)

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter @zextras/carbonio-ui-soap-lib && npm install`
- Only `package.json` and `package-lock.json` were modified.

🤖 Generated by the `update-deps` skill.
