### PR TITLE
chore(deps): bump darkreader from 4.9.79 to 4.9.120

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@zextras/carbonio-design-system": "12.0.2",
 				"@zextras/carbonio-ui-preview": "4.0.2",
 				"@zextras/carbonio-ui-soap-lib": "1.0.4",
-				"darkreader": "^4.9.120",
+				"darkreader": "4.9.120",
 				"date-fns": "^4.1.0",
 				"i18next": "^22.5.1",
 				"i18next-chained-backend": "^4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@zextras/carbonio-design-system": "12.0.2",
 				"@zextras/carbonio-ui-preview": "4.0.2",
 				"@zextras/carbonio-ui-soap-lib": "1.0.4",
-				"darkreader": "^4.9.79",
+				"darkreader": "^4.9.120",
 				"date-fns": "^4.1.0",
 				"i18next": "^22.5.1",
 				"i18next-chained-backend": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 		"@zextras/carbonio-design-system": "12.0.2",
 		"@zextras/carbonio-ui-preview": "4.0.2",
 		"@zextras/carbonio-ui-soap-lib": "1.0.4",
-		"darkreader": "^4.9.120",
+		"darkreader": "4.9.120",
 		"date-fns": "^4.1.0",
 		"i18next": "^22.5.1",
 		"i18next-chained-backend": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 		"@zextras/carbonio-design-system": "12.0.2",
 		"@zextras/carbonio-ui-preview": "4.0.2",
 		"@zextras/carbonio-ui-soap-lib": "1.0.4",
-		"darkreader": "^4.9.79",
+		"darkreader": "^4.9.120",
 		"date-fns": "^4.1.0",
 		"i18next": "^22.5.1",
 		"i18next-chained-backend": "^4.6.2",


### PR DESCRIPTION
## Bump `darkreader` from `4.9.79` to `4.9.120`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `4.9.79`
- **New:** `4.9.120`
- **npm:** https://www.npmjs.com/package/darkreader/v/4.9.120

### Changelog


#### [`v4.9.80`](https://github.com/darkreader/darkreader/releases/tag/v4.9.80)

_No release notes._

---

#### [`v4.9.81`](https://github.com/darkreader/darkreader/releases/tag/v4.9.81)

_No release notes._

---

#### [`v4.9.82`](https://github.com/darkreader/darkreader/releases/tag/v4.9.82)

_No release notes._

---

#### [`v4.9.83`](https://github.com/darkreader/darkreader/releases/tag/v4.9.83)

_No release notes._

---

#### [`v4.9.84`](https://github.com/darkreader/darkreader/releases/tag/v4.9.84)

_No release notes._

---

#### [`v4.9.85`](https://github.com/darkreader/darkreader/releases/tag/v4.9.85)

_No release notes._

---

#### [`v4.9.86`](https://github.com/darkreader/darkreader/releases/tag/v4.9.86)

_No release notes._

---

#### [`v4.9.87`](https://github.com/darkreader/darkreader/releases/tag/v4.9.87)

_No release notes._

---

#### [`v4.9.88`](https://github.com/darkreader/darkreader/releases/tag/v4.9.88)

_No release notes._

---

#### [`v4.9.89.1`](https://github.com/darkreader/darkreader/releases/tag/v4.9.89.1)

_No release notes._

---

#### [`v4.9.89`](https://github.com/darkreader/darkreader/releases/tag/v4.9.89)

_No release notes._

---

#### [`v4.9.90`](https://github.com/darkreader/darkreader/releases/tag/v4.9.90)

_No release notes._

---

#### [`v4.9.92`](https://github.com/darkreader/darkreader/releases/tag/v4.9.92)

_No release notes._

---

#### [`v4.9.94`](https://github.com/darkreader/darkreader/releases/tag/v4.9.94)

_No release notes._

---

#### [`v4.9.95`](https://github.com/darkreader/darkreader/releases/tag/v4.9.95)

_No release notes._

---

#### [`v4.9.96`](https://github.com/darkreader/darkreader/releases/tag/v4.9.96)

_No release notes._

---

#### [`v4.9.97`](https://github.com/darkreader/darkreader/releases/tag/v4.9.97)

_No release notes._

---

#### [`v4.9.98`](https://github.com/darkreader/darkreader/releases/tag/v4.9.98)

_No release notes._

---

#### [`v4.9.99`](https://github.com/darkreader/darkreader/releases/tag/v4.9.99)

_No release notes._

---

#### [`v4.9.100`](https://github.com/darkreader/darkreader/releases/tag/v4.9.100)

_No release notes._

---

#### [`v4.9.101`](https://github.com/darkreader/darkreader/releases/tag/v4.9.101)

_No release notes._

---

#### [`v4.9.102`](https://github.com/darkreader/darkreader/releases/tag/v4.9.102)

_No release notes._

---

#### [`v4.9.103`](https://github.com/darkreader/darkreader/releases/tag/v4.9.103)

_No release notes._

---

#### [`v4.9.104`](https://github.com/darkreader/darkreader/releases/tag/v4.9.104)

_No release notes._

---

#### [`v4.9.105`](https://github.com/darkreader/darkreader/releases/tag/v4.9.105)

_No release notes._

---

#### [`v4.9.106`](https://github.com/darkreader/darkreader/releases/tag/v4.9.106)

_No release notes._

---

#### [`v4.9.107`](https://github.com/darkreader/darkreader/releases/tag/v4.9.107)

_No release notes._

---

#### [`v4.9.108`](https://github.com/darkreader/darkreader/releases/tag/v4.9.108)

_No release notes._

---

#### [`v4.9.109`](https://github.com/darkreader/darkreader/releases/tag/v4.9.109)

_No release notes._

---

#### [`v4.9.110`](https://github.com/darkreader/darkreader/releases/tag/v4.9.110)

_No release notes._

---

#### [`v4.9.112`](https://github.com/darkreader/darkreader/releases/tag/v4.9.112)

_No release notes._

---

#### [`v4.9.113`](https://github.com/darkreader/darkreader/releases/tag/v4.9.113)

_No release notes._

---

#### [`v4.9.114`](https://github.com/darkreader/darkreader/releases/tag/v4.9.114)

_No release notes._

---

#### [`v4.9.115`](https://github.com/darkreader/darkreader/releases/tag/v4.9.115)

_No release notes._

---

#### [`v4.9.116`](https://github.com/darkreader/darkreader/releases/tag/v4.9.116)

_No release notes._

---

#### [`v4.9.117`](https://github.com/darkreader/darkreader/releases/tag/v4.9.117)

_No release notes._

---

#### [`v4.9.118`](https://github.com/darkreader/darkreader/releases/tag/v4.9.118)

_No release notes._

---

#### [`v4.9.119`](https://github.com/darkreader/darkreader/releases/tag/v4.9.119)

_No release notes._

---

#### [`v4.9.120`](https://github.com/darkreader/darkreader/releases/tag/v4.9.120)

_No release notes._

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter darkreader && npm install`
- Only `package.json` and `package-lock.json` were modified.

🤖 Generated by the `update-deps` skill.
