### PR TITLE
chore(deps): bump i18next-chained-backend from 4.6.2 to 4.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"darkreader": "^4.9.79",
 				"date-fns": "^4.1.0",
 				"i18next": "^22.5.1",
-				"i18next-chained-backend": "^4.6.2",
+				"i18next-chained-backend": "^4.6.3",
 				"i18next-http-backend": "^2.5.0",
 				"immer": "^10.0.3",
 				"lodash": "^4.17.23",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
 		"darkreader": "^4.9.79",
 		"date-fns": "^4.1.0",
 		"i18next": "^22.5.1",
-		"i18next-chained-backend": "^4.6.2",
+		"i18next-chained-backend": "^4.6.3",
 		"i18next-http-backend": "^2.5.0",
 		"immer": "^10.0.3",
 		"lodash": "^4.17.23",


### PR DESCRIPTION
## Bump `i18next-chained-backend` from `4.6.2` to `4.6.3`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `4.6.2`
- **New:** `4.6.3`
- **npm:** https://www.npmjs.com/package/i18next-chained-backend/v/4.6.3

### Changelog

> No GitHub releases retrievable for [i18next/i18next-chained-backend](https://github.com/i18next/i18next-chained-backend).
> See the [releases page](https://github.com/i18next/i18next-chained-backend/releases) or the [npm page](https://www.npmjs.com/package/i18next-chained-backend/v/4.6.3).

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter i18next-chained-backend && npm install`
- Only `package.json` and `package-lock.json` were modified.

🤖 Generated by the `update-deps` skill.
