### PR TITLE
chore(deps): bump i18next-http-backend from 2.5.0 to 2.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"date-fns": "^4.1.0",
 				"i18next": "^22.5.1",
 				"i18next-chained-backend": "^4.6.2",
-				"i18next-http-backend": "^2.5.0",
+				"i18next-http-backend": "^2.7.3",
 				"immer": "^10.0.3",
 				"lodash": "^4.17.23",
 				"posthog-js": "^1.360.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
 		"date-fns": "^4.1.0",
 		"i18next": "^22.5.1",
 		"i18next-chained-backend": "^4.6.2",
-		"i18next-http-backend": "^2.5.0",
+		"i18next-http-backend": "^2.7.3",
 		"immer": "^10.0.3",
 		"lodash": "^4.17.23",
 		"posthog-js": "^1.360.0",


### PR DESCRIPTION
## Bump `i18next-http-backend` from `2.5.0` to `2.7.3`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `2.5.0`
- **New:** `2.7.3`
- **Minor jump:** +2
- **npm:** https://www.npmjs.com/package/i18next-http-backend/v/2.7.3

### Changelog

> No GitHub releases retrievable for [i18next/i18next-http-backend](https://github.com/i18next/i18next-http-backend).
> See the [releases page](https://github.com/i18next/i18next-http-backend/releases) or the [npm page](https://www.npmjs.com/package/i18next-http-backend/v/2.7.3).

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter i18next-http-backend && npm install`
- Only `package.json` and `package-lock.json` were modified.

🤖 Generated by the `update-deps` skill.
