### PR TITLE
chore(deps): bump lodash from 4.17.23 to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"i18next-chained-backend": "^4.6.2",
 				"i18next-http-backend": "^2.5.0",
 				"immer": "^10.0.3",
-				"lodash": "^4.18.1",
+				"lodash": "4.18.1",
 				"posthog-js": "^1.360.0",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"i18next-chained-backend": "^4.6.2",
 				"i18next-http-backend": "^2.5.0",
 				"immer": "^10.0.3",
-				"lodash": "^4.17.23",
+				"lodash": "^4.18.1",
 				"posthog-js": "^1.360.0",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
@@ -3945,6 +3945,13 @@
 				"@microsoft/tsdoc-config": "~0.18.1",
 				"@rushstack/node-core-library": "5.20.3"
 			}
+		},
+		"node_modules/@microsoft/api-extractor/node_modules/lodash": {
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
 			"version": "6.0.0",
@@ -14379,9 +14386,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
 		"i18next-chained-backend": "^4.6.2",
 		"i18next-http-backend": "^2.5.0",
 		"immer": "^10.0.3",
-		"lodash": "^4.17.23",
+		"lodash": "^4.18.1",
 		"posthog-js": "^1.360.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
 		"i18next-chained-backend": "^4.6.2",
 		"i18next-http-backend": "^2.5.0",
 		"immer": "^10.0.3",
-		"lodash": "^4.18.1",
+		"lodash": "4.18.1",
 		"posthog-js": "^1.360.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",


### PR DESCRIPTION
## Bump `lodash` from `4.17.23` to `4.18.1`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `4.17.23`
- **New:** `4.18.1`
- **Minor jump:** +1
- **npm:** https://www.npmjs.com/package/lodash/v/4.18.1

> Questo aggiornamento risolve una vulnerabilità **HIGH** su `lodash` (<=4.17.23): *Code Injection via `_.template`* ([GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc)) e *Prototype Pollution via array path bypass in `_.unset` / `_.omit`* ([GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh)).

### Changelog


#### [`4.18.0`](https://github.com/lodash/lodash/releases/tag/4.18.0)

## v4.18.0

**Full Changelog**: https://github.com/lodash/lodash/compare/4.17.23...4.18.0

### Security

**`_.unset` / `_.omit`**: Fixed prototype pollution via `constructor`/`prototype` path traversal ([GHSA-f23m-r3pf-42rh](https://github.com/lodash/lodash/security/advisories/GHSA-f23m-r3pf-42rh), [fe8d32e](https://github.com/lodash/lodash/commit/fe8d32eda854377349a4f922ab7655c8e5df9a0b)). Previously, array-wrapped path segments and primitive roots could bypass the existing guards, allowing deletion of properties from built-in prototypes. Now `constructor` and `prototype` are blocked unconditionally as non-terminal path keys, matching `baseSet`. Calls that previously returned `true` and deleted the property now return `false` and leave the target untouched.

**`_.template`**: Fixed code injection via `imports` keys ([GHSA-r5fr-rjxr-66jc](https://github.com/lodash/lodash/security/advisories/GHSA-r5fr-rjxr-66jc), CVE-2026-4800, [879aaa9](https://github.com/lodash/lodash/commit/879aaa93132d78c2f8d20c60279da9f8b21576d6)). Fixes an incomplete patch for CVE-2021-23337. The `variable` option was validated against `reForbiddenIdentifierChars` but `importsKeys` was left unguarded, allowing code injection via the same `Function()` constructor sink. `imports` keys containing forbidden identifier characters now throw `"Invalid imports option passed into _.template"`.

### Docs
- Add security notice for `_.template` in threat model and API docs ([#6099](https://github.com/lodash/lodash/pull/6099))
- Document `lower > upper` behavior in `_.random` ([#6115](https://github.com/lodash/lodash/pull/6115))
- Fix quotes in `_.compact` jsdoc ([#6090](https://github.com/lodash/lodash/pull/6090))

### `lodash.*` modular packages

[Diff](https://github.com/lodash/lodash/pull/6157)

We have also regenerated and published a select number of the `lodash.*` modular packages. 

These modular packages had fallen out of sync significantly from the minor/patch updates to lodash. Specifically, we have brought the following packages up to parity w/ the latest lodash release because they have had CVEs on them in the past:

- [lodash.orderby](https://www.npmjs.com/package/lodash.orderby)
- [lodash.tonumber](https://www.npmjs.com/package/lodash.tonumber)
- [lodash.trim](https://www.npmjs.com/package/lodash.trim)
- [lodash.trimend](https://www.npmjs.com/package/lodash.trimend)
- [lodash.sortedindexby](https://www.npmjs.com/package/lodash.sortedindexby)
- [lodash.zipobjectdeep](https://www.npmjs.com/package/lodash.zipobjectdeep)
- [lodash.unset](https://www.npmjs.com/package/lodash.unset)
- [lodash.omit](https://www.npmjs.com/package/lodash.omit)
- [lodash.template](https://www.npmjs.com/package/lodash.template)

---

#### [`4.18.1`](https://github.com/lodash/lodash/releases/tag/4.18.1)

## Bugs

Fixes a `ReferenceError` issue in `lodash` `lodash-es` `lodash-amd` and `lodash.template` when using the `template` and `fromPairs` functions from the modular builds. See https://github.com/lodash/lodash/issues/6167#issuecomment-4165269769

These defects were related to how lodash distributions are built from the main branch using https://github.com/lodash-archive/lodash-cli. When internal dependencies change inside lodash functions, equivalent updates need to be made to a mapping in the lodash-cli. (hey, it was ahead of its time once upon a time!). We know this, but we missed it in the last release. It's the kind of thing that passes in CI, but fails bc the build is not the same thing you tested.

There is no diff on main for this, but you can see the diffs for each of the npm packages on their respective branches:

- `lodash`: https://github.com/lodash/lodash/compare/4.18.0-npm...4.18.1-npm
- `lodash-es`: https://github.com/lodash/lodash/compare/4.18.0-es...4.18.1-es
- `lodash-amd`: https://github.com/lodash/lodash/compare/4.18.0-amd...4.18.1-amd
- `lodash.template`https://github.com/lodash/lodash/compare/4.18.0-npm-packages...4.18.1-npm-packages

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter lodash && npm install`
- Only `package.json` and `package-lock.json` were modified.

🤖 Generated by the `update-deps` skill.
