### PR TITLE
chore(deps): bump react-router-dom from 6.30.0 to 6.30.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-i18next": "^12.3.1",
-				"react-router-dom": "^6.30.0",
+				"react-router-dom": "^6.30.3",
 				"zustand": "^5.0.12"
 			},
 			"devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-i18next": "^12.3.1",
-				"react-router-dom": "^6.30.3",
+				"react-router-dom": "6.30.3",
 				"zustand": "^5.0.12"
 			},
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-i18next": "^12.3.1",
-		"react-router-dom": "^6.30.0",
+		"react-router-dom": "^6.30.3",
 		"zustand": "^5.0.12"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-i18next": "^12.3.1",
-		"react-router-dom": "^6.30.3",
+		"react-router-dom": "6.30.3",
 		"zustand": "^5.0.12"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
## Bump `react-router-dom` from `6.30.0` to `6.30.3`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `6.30.0`
- **New:** `6.30.3`
- **npm:** https://www.npmjs.com/package/react-router-dom/v/6.30.3

### Changelog


#### [`react-router@6.30.1`](https://github.com/remix-run/react-router/releases/tag/react-router%406.30.1) — v6.30.1

See the changelog for release notes: https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#v6301

---

#### [`react-router@6.30.2`](https://github.com/remix-run/react-router/releases/tag/react-router%406.30.2) — v6.30.2

See the changelog for release notes: https://github.com/remix-run/react-router/blob/v6/CHANGELOG.md#v6302

---

#### [`react-router@6.30.3`](https://github.com/remix-run/react-router/releases/tag/react-router%406.30.3) — v6.30.3

See the changelog for release notes: https://github.com/remix-run/react-router/blob/v6/CHANGELOG.md#v6303

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter react-router-dom && npm install`
- Only `package.json` and `package-lock.json` were modified.

🤖 Generated by the `update-deps` skill.
