### PR TITLE
chore(deps): bump posthog-js from 1.360.0 to 1.369.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"i18next-http-backend": "^2.5.0",
 				"immer": "10.2.0",
 				"lodash": "4.18.1",
-				"posthog-js": "^1.360.0",
+				"posthog-js": "1.369.1",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-i18next": "^12.3.1",
@@ -4735,18 +4735,15 @@
 			"license": "MIT"
 		},
 		"node_modules/@posthog/core": {
-			"version": "1.24.1",
-			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.24.1.tgz",
-			"integrity": "sha512-e8AciAnc6MRFws89ux8lJKFAaI03yEon0ASDoUO7yS91FVqbUGXYekObUUR3LHplcg+pmyiJBI0jolY0SFbGRA==",
-			"license": "MIT",
-			"dependencies": {
-				"cross-spawn": "^7.0.6"
-			}
+			"version": "1.25.2",
+			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.25.2.tgz",
+			"integrity": "sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==",
+			"license": "MIT"
 		},
 		"node_modules/@posthog/types": {
-			"version": "1.363.6",
-			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.363.6.tgz",
-			"integrity": "sha512-SPU8psjrpK8prfFyYwvb25F1AgqSM32zdU1XPVIhUa107Cyw+VGw38Gv+AeqkEoAYQE2TFlWJT8DWUrw/mNDoQ==",
+			"version": "1.369.1",
+			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.369.1.tgz",
+			"integrity": "sha512-5sUMa/gmGloazdnDZF8hfzMhGAhxtuTy3v7plnx+mR72fjDyg0aUQjmCeoxxyFOrBAO5aVYxESxPVKJepE6EfA==",
 			"license": "MIT"
 		},
 		"node_modules/@protobufjs/aspromise": {
@@ -9224,6 +9221,7 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -13627,6 +13625,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/isobject": {
@@ -15659,6 +15658,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -16052,9 +16052,9 @@
 			"license": "MIT"
 		},
 		"node_modules/posthog-js": {
-			"version": "1.363.6",
-			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.363.6.tgz",
-			"integrity": "sha512-eQ+Ypml3JOEMQWt21XEea6J8vD77TNyoz4Yv/xxjlTRja+ilmJtQw/SuVAB3BobjgHKYUomXX7Fc4gH/zTVpbg==",
+			"version": "1.369.1",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.369.1.tgz",
+			"integrity": "sha512-xerj/T3NE65H9cqUKzg2LbNmavTC/qr26CnE+yBw+yNyro6Fmvs9+CMvRc2+RkDsoOdSmrq9cwR9noZqfjC2Kg==",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",
@@ -16062,8 +16062,8 @@
 				"@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
 				"@opentelemetry/resources": "^2.2.0",
 				"@opentelemetry/sdk-logs": "^0.208.0",
-				"@posthog/core": "1.24.1",
-				"@posthog/types": "1.363.6",
+				"@posthog/core": "1.25.2",
+				"@posthog/types": "1.369.1",
 				"core-js": "^3.38.1",
 				"dompurify": "^3.3.2",
 				"fflate": "^0.4.8",
@@ -17441,6 +17441,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -17453,6 +17454,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -19827,6 +19829,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
 		"i18next-http-backend": "^2.5.0",
 		"immer": "10.2.0",
 		"lodash": "4.18.1",
-		"posthog-js": "^1.360.0",
+		"posthog-js": "1.369.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-i18next": "^12.3.1",


### PR DESCRIPTION
## Bump `posthog-js` from `1.360.0` to `1.369.0`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `1.360.0`
- **New:** `1.369.0`
- **Minor jump:** +9
- **npm:** https://www.npmjs.com/package/posthog-js/v/1.369.0

### Changelog


#### [`posthog-js@1.360.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.360.1)

## 1.360.1

### Patch Changes

- Updated dependencies [[`4009c15`](https://github.com/PostHog/posthog-js/commit/4009c15c85c96b5cf99fdbcda448b9893c95541e)]:
    - @posthog/core@1.23.3
    - @posthog/types@1.360.1

---

#### [`@posthog/types@1.360.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.360.1)

## 1.360.1

---

#### [`posthog-js@1.360.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.360.2)

## 1.360.2

### Patch Changes

- [#3236](https://github.com/PostHog/posthog-js/pull/3236) [`bc30c2d`](https://github.com/PostHog/posthog-js/commit/bc30c2d988bb307e811d97711f208c125eefba3a) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - fix: Calling reset() now automatically reloads feature flags
  (2026-03-13)
- Updated dependencies [[`bc30c2d`](https://github.com/PostHog/posthog-js/commit/bc30c2d988bb307e811d97711f208c125eefba3a), [`bc30c2d`](https://github.com/PostHog/posthog-js/commit/bc30c2d988bb307e811d97711f208c125eefba3a)]:
    - @posthog/core@1.23.4
    - @posthog/types@1.360.2

---

#### [`@posthog/types@1.360.2`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.360.2)

## 1.360.2

---

#### [`posthog-js@1.361.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.361.0)

## 1.361.0

### Minor Changes

- [#3201](https://github.com/PostHog/posthog-js/pull/3201) [`552c018`](https://github.com/PostHog/posthog-js/commit/552c01843b9ae1fbf8fdf1a2e98e0b7fdc37c851) Thanks [@frankh](https://github.com/frankh)! - Add a serviceName config option to logs config
  (2026-03-18)

- [#3240](https://github.com/PostHog/posthog-js/pull/3240) [`e4a58d0`](https://github.com/PostHog/posthog-js/commit/e4a58d0a071c7605a69ae4492efd895cd50047bd) Thanks [@marandaneto](https://github.com/marandaneto)! - Add internal `_overrideSDKInfo` method to allow wrapper SDKs to override `$lib` and `$lib_version` event properties
  (2026-03-18)

- [#3241](https://github.com/PostHog/posthog-js/pull/3241) [`fe1fd7b`](https://github.com/PostHog/posthog-js/commit/fe1fd7b222b2ca51164e01fceca892628efac89c) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - feat: add `advanced_feature_flags_dedup_per_session` config option to scope `$feature_flag_called` deduplication to the current session
  (2026-03-18)

### Patch Changes

- [#3239](https://github.com/PostHog/posthog-js/pull/3239) [`bf4f078`](https://github.com/PostHog/posthog-js/commit/bf4f078096c506906afecb1dbe9fc31100900a0f) Thanks [@jonathanlab](https://github.com/jonathanlab)! - fix: debug mode not persisting across page navigations
  (2026-03-18)

- [#3228](https://github.com/PostHog/posthog-js/pull/3228) [`8773fdf`](https://github.com/PostHog/posthog-js/commit/8773fdfdb87980da3db1f141099577424b35153b) Thanks [@TueHaulund](https://github.com/TueHaulund)! - fix: restart session recorder when session rotates externally while idle, preventing "Recording not found" for sessions where analytics events triggered session rotation
  (2026-03-18)
- Updated dependencies [[`552c018`](https://github.com/PostHog/posthog-js/commit/552c01843b9ae1fbf8fdf1a2e98e0b7fdc37c851), [`fe1fd7b`](https://github.com/PostHog/posthog-js/commit/fe1fd7b222b2ca51164e01fceca892628efac89c)]:
    - @posthog/types@1.361.0

---

#### [`@posthog/types@1.361.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.361.0)

## 1.361.0

### Minor Changes

- [#3241](https://github.com/PostHog/posthog-js/pull/3241) [`fe1fd7b`](https://github.com/PostHog/posthog-js/commit/fe1fd7b222b2ca51164e01fceca892628efac89c) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - feat: add `advanced_feature_flags_dedup_per_session` config option to scope `$feature_flag_called` deduplication to the current session
  (2026-03-18)

### Patch Changes

- [#3201](https://github.com/PostHog/posthog-js/pull/3201) [`552c018`](https://github.com/PostHog/posthog-js/commit/552c01843b9ae1fbf8fdf1a2e98e0b7fdc37c851) Thanks [@frankh](https://github.com/frankh)! - Add a serviceName config option to logs config
  (2026-03-18)

---

#### [`posthog-js@1.361.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.361.1)

## 1.361.1

### Patch Changes

- [#3249](https://github.com/PostHog/posthog-js/pull/3249) [`c265d62`](https://github.com/PostHog/posthog-js/commit/c265d6207c43986d0599ad2464df53e2b813f08c) Thanks [@marandaneto](https://github.com/marandaneto)! - fix: preserve `_overrideSDKInfo` from terser mangling so wrapper SDKs can call it
  (2026-03-18)
- Updated dependencies []:
    - @posthog/types@1.361.1

---

#### [`@posthog/types@1.361.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.361.1)

## 1.361.1

---

#### [`posthog-js@1.362.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.362.0)

## 1.362.0

### Minor Changes

- [#3244](https://github.com/PostHog/posthog-js/pull/3244) [`ff8a93e`](https://github.com/PostHog/posthog-js/commit/ff8a93e99bb9bab98d02074d84973430d279a29d) Thanks [@sampennington](https://github.com/sampennington)! - Fixed $set_once initial person properties (e.g. $initial_current_url) not being included with $identify calls when they had already been sent with a prior event. This ensures initial properties are reliably set when identifying users across subdomains, even if an anonymous event was captured first.
  (2026-03-18)

### Patch Changes

- Updated dependencies [[`9cd2313`](https://github.com/PostHog/posthog-js/commit/9cd23138343e1020811f85853d6016cc985bb24f)]:
    - @posthog/core@1.24.0
    - @posthog/types@1.362.0

---

#### [`@posthog/types@1.362.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.362.0)

## 1.362.0

---

#### [`posthog-js@1.363.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.363.0)

## 1.363.0

### Minor Changes

- [#3247](https://github.com/PostHog/posthog-js/pull/3247) [`7efa558`](https://github.com/PostHog/posthog-js/commit/7efa558fa0a5e3355d4f3c7974ec20b6a1b810b4) Thanks [@dmarticus](https://github.com/dmarticus)! - prevent silent identity switch during bootstrap and auto-identify anonymous users
  (2026-03-20)

### Patch Changes

- [#3245](https://github.com/PostHog/posthog-js/pull/3245) [`1acd6fd`](https://github.com/PostHog/posthog-js/commit/1acd6fdfaaa46da71ca15bba2916c3bb81c3e7ef) Thanks [@dmarticus](https://github.com/dmarticus)! - handle plain array and object forms in overrideFeatureFlags
  (2026-03-20)
- Updated dependencies [[`1acd6fd`](https://github.com/PostHog/posthog-js/commit/1acd6fdfaaa46da71ca15bba2916c3bb81c3e7ef)]:
    - @posthog/types@1.363.0

---

#### [`@posthog/types@1.363.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.363.0)

## 1.363.0

### Patch Changes

- [#3245](https://github.com/PostHog/posthog-js/pull/3245) [`1acd6fd`](https://github.com/PostHog/posthog-js/commit/1acd6fdfaaa46da71ca15bba2916c3bb81c3e7ef) Thanks [@dmarticus](https://github.com/dmarticus)! - handle plain array and object forms in overrideFeatureFlags
  (2026-03-20)

---

#### [`posthog-js@1.363.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.363.1)

## 1.363.1

### Patch Changes

- Updated dependencies [[`314120a`](https://github.com/PostHog/posthog-js/commit/314120aa2377b3c8031dd774833fe9082ecdbd39)]:
    - @posthog/core@1.24.1
    - @posthog/types@1.363.1

---

#### [`@posthog/types@1.363.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.363.1)

## 1.363.1

---

#### [`posthog-js@1.363.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.363.2)

## 1.363.2

### Patch Changes

- [#3267](https://github.com/PostHog/posthog-js/pull/3267) [`e5ef520`](https://github.com/PostHog/posthog-js/commit/e5ef5201bf764aac11a765549f9561010d3b4329) Thanks [@ksvat](https://github.com/ksvat)! - bump rrweb dependency version
  (2026-03-23)

- [#3260](https://github.com/PostHog/posthog-js/pull/3260) [`1435ec8`](https://github.com/PostHog/posthog-js/commit/1435ec8bb64dd6ac8f5359630b7f01b051cc5fe6) Thanks [@kyleswank](https://github.com/kyleswank)! - Log warning instead of throwing error when session recording script is blocked by ad blockers
  (2026-03-23)
- Updated dependencies []:
    - @posthog/types@1.363.2

---

#### [`@posthog/types@1.363.2`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.363.2)

## 1.363.2

---

#### [`posthog-js@1.363.3`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.363.3)

## 1.363.3

### Patch Changes

- [#3253](https://github.com/PostHog/posthog-js/pull/3253) [`42fbd41`](https://github.com/PostHog/posthog-js/commit/42fbd4190ac4c4ce850158407512d15fa2e590c8) Thanks [@marandaneto](https://github.com/marandaneto)! - Reduce browser SDK bundle size by ~6.6 KB (-3.7%) through code modernization, build config tuning, string deduplication, enum-to-const conversions, and property access shorthand getters.
  (2026-03-23)
- Updated dependencies []:
    - @posthog/types@1.363.3

---

#### [`@posthog/types@1.363.3`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.363.3)

## 1.363.3

---

#### [`posthog-js@1.363.4`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.363.4)

## 1.363.4

### Patch Changes

- [#3275](https://github.com/PostHog/posthog-js/pull/3275) [`664a11b`](https://github.com/PostHog/posthog-js/commit/664a11b083cf0a92630676207abb52aeb6a7c1e9) Thanks [@fasyy612](https://github.com/fasyy612)! - bump rrweb dependency version
  (2026-03-24)
- Updated dependencies []:
    - @posthog/types@1.363.4

---

#### [`@posthog/types@1.363.4`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.363.4)

## 1.363.4

---

#### [`posthog-js@1.363.5`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.363.5)

## 1.363.5

### Patch Changes

- [#3278](https://github.com/PostHog/posthog-js/pull/3278) [`c59dc90`](https://github.com/PostHog/posthog-js/commit/c59dc90e167f2e1dc3fc4e53d2d716f9dc5e3c70) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - Add tree-shakeable ESM extension-bundles entry point for slim builds
  (2026-03-25)

- [#3274](https://github.com/PostHog/posthog-js/pull/3274) [`ba08262`](https://github.com/PostHog/posthog-js/commit/ba08262a0bcf4ae1db3ef3bb841e0ad07002fbea) Thanks [@pauldambra](https://github.com/pauldambra)! - fix: document visibility change shoudln't capture dead click
  (2026-03-25)
- Updated dependencies [[`ba08262`](https://github.com/PostHog/posthog-js/commit/ba08262a0bcf4ae1db3ef3bb841e0ad07002fbea)]:
    - @posthog/types@1.363.5

---

#### [`@posthog/types@1.363.5`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.363.5)

## 1.363.5

### Patch Changes

- [#3274](https://github.com/PostHog/posthog-js/pull/3274) [`ba08262`](https://github.com/PostHog/posthog-js/commit/ba08262a0bcf4ae1db3ef3bb841e0ad07002fbea) Thanks [@pauldambra](https://github.com/pauldambra)! - fix: document visibility change shoudln't capture dead click
  (2026-03-25)

---

#### [`posthog-js@1.363.6`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.363.6)

## 1.363.6

### Patch Changes

- [#3279](https://github.com/PostHog/posthog-js/pull/3279) [`32edaad`](https://github.com/PostHog/posthog-js/commit/32edaadd509e32a3a679142ccb704fd9e404d1a2) Thanks [@pauldambra](https://github.com/pauldambra)! - Bump @posthog/rrweb packages to 0.0.51, which includes:
    - PostHog/posthog-rrweb#145: fix: handle cross-origin iframe errors during stop handler cleanup
    - PostHog/posthog-rrweb#148: fix: mask textarea innerText mutations
    - PostHog/posthog-rrweb#150: fix: guard WebGLRenderingContext access for iOS compatibility
    - PostHog/posthog-rrweb#151: refactor: extract slimDOMDefaults into shared function
    - PostHog/posthog-rrweb#152: fix: improve nested CSS rule handling
    - PostHog/posthog-rrweb#153: fix: allow clearing adopted stylesheets with empty strings
    - PostHog/posthog-rrweb#154: fix: prevent object reference mutation breaking remote CSS replay
    - PostHog/posthog-rrweb#156: fix: catch all SecurityError variants in stop handler cleanup (2026-03-26)
- Updated dependencies []:
    - @posthog/types@1.363.6

---

#### [`@posthog/types@1.363.6`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.363.6)

## 1.363.6

---

#### [`posthog-js@1.364.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.364.0)

## 1.364.0

### Minor Changes

- [#3285](https://github.com/PostHog/posthog-js/pull/3285) [`00a5079`](https://github.com/PostHog/posthog-js/commit/00a50795a16e9274fc6b4ea642b4a5e270f07222) Thanks [@pauldambra](https://github.com/pauldambra)! - Reject the strings "undefined" and "null" in posthog.identify(). All invalid distinct IDs now log a critical console error (always visible, not debug-only).
  (2026-03-27)

### Patch Changes

- [#3286](https://github.com/PostHog/posthog-js/pull/3286) [`8d34289`](https://github.com/PostHog/posthog-js/commit/8d34289f7cf91945223eed4366b11fb187a63a40) Thanks [@marandaneto](https://github.com/marandaneto)! - Use async native CompressionStream for gzip compression to avoid blocking the main thread
  (2026-03-27)
- Updated dependencies [[`8d34289`](https://github.com/PostHog/posthog-js/commit/8d34289f7cf91945223eed4366b11fb187a63a40)]:
    - @posthog/core@1.24.2
    - @posthog/types@1.364.0

---

#### [`@posthog/types@1.364.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.364.0)

## 1.364.0

---

#### [`posthog-js@1.364.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.364.1)

## 1.364.1

### Patch Changes

- Updated dependencies [[`4bdfdbc`](https://github.com/PostHog/posthog-js/commit/4bdfdbcfe6a5600664a609a6b17c7d7cb72cd20f)]:
    - @posthog/core@1.24.3
    - @posthog/types@1.364.1

---

#### [`@posthog/types@1.364.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.364.1)

## 1.364.1

---

#### [`posthog-js@1.364.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.364.2)

## 1.364.2

### Patch Changes

- [#3297](https://github.com/PostHog/posthog-js/pull/3297) [`341caaf`](https://github.com/PostHog/posthog-js/commit/341caaf627d752b35a3b9461a8b1f1fd532f306f) Thanks [@marandaneto](https://github.com/marandaneto)! - fix: wrap sendBeacon body in Blob to ensure Content-Type header is set
  (2026-03-30)
- Updated dependencies [[`a863914`](https://github.com/PostHog/posthog-js/commit/a863914bca09643f2aef7ca029b96de9cbfbc24c)]:
    - @posthog/core@1.24.4
    - @posthog/types@1.364.2

---

#### [`@posthog/types@1.364.2`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.364.2)

## 1.364.2

---

#### [`posthog-js@1.364.3`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.364.3)

## 1.364.3

### Patch Changes

- [#3300](https://github.com/PostHog/posthog-js/pull/3300) [`bab5f3a`](https://github.com/PostHog/posthog-js/commit/bab5f3a0c061dc48c2b573136c03758a3ba3c301) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - Strip workspace:\* references from lib/package.json after build
  (2026-03-31)
- Updated dependencies []:
    - @posthog/types@1.364.3

---

#### [`@posthog/types@1.364.3`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.364.3)

## 1.364.3

---

#### [`posthog-js@1.364.4`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.364.4)

## 1.364.4

### Patch Changes

- [#3298](https://github.com/PostHog/posthog-js/pull/3298) [`2365df5`](https://github.com/PostHog/posthog-js/commit/2365df5c420fb88dccb74c85beeb058be92eb66e) Thanks [@TueHaulund](https://github.com/TueHaulund)! - fix: skip deep copy for snapshot/exception events to prevent stack overflow on deeply nested DOM trees
  (2026-03-31)
- Updated dependencies []:
    - @posthog/types@1.364.4

---

#### [`@posthog/types@1.364.4`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.364.4)

## 1.364.4

---

#### [`posthog-js@1.364.5`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.364.5)

## 1.364.5

### Patch Changes

- [#3309](https://github.com/PostHog/posthog-js/pull/3309) [`197eeda`](https://github.com/PostHog/posthog-js/commit/197eeda0b09fd2671a8a40f1bfd48a7b940f7371) Thanks [@marandaneto](https://github.com/marandaneto)! - Extract CLI and sourcemap utilities from @posthog/core into @posthog/plugin-utils to remove cross-spawn from React Native dependencies
  (2026-04-01)

- [#3312](https://github.com/PostHog/posthog-js/pull/3312) [`c5feb5c`](https://github.com/PostHog/posthog-js/commit/c5feb5c35eefe0a459facc3b72752ab7d6696c1c) Thanks [@TueHaulund](https://github.com/TueHaulund)! - Bump @posthog/rrweb-\* to 0.0.52 — adds error recovery to the canvas FPS snapshot pipeline, preventing canvas recording from permanently stopping when createImageBitmap or the worker encounters an error
  (2026-04-01)

- [#3315](https://github.com/PostHog/posthog-js/pull/3315) [`7b944fc`](https://github.com/PostHog/posthog-js/commit/7b944fc2a6099c0dfa4aa28f55872bd226b17b37) Thanks [@TueHaulund](https://github.com/TueHaulund)! - Bump @posthog/rrweb-\* to 0.0.53 — fixes infinite recursion crash ("Maximum call stack size exceeded") when calling posthog.reset() or restarting the recorder on pages with shadow DOM elements (e.g. CometChat)
  (2026-04-01)
- Updated dependencies [[`197eeda`](https://github.com/PostHog/posthog-js/commit/197eeda0b09fd2671a8a40f1bfd48a7b940f7371)]:
    - @posthog/core@1.24.5
    - @posthog/types@1.364.5

---

#### [`@posthog/types@1.364.5`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.364.5)

## 1.364.5

---

#### [`posthog-js@1.364.6`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.364.6)

## 1.364.6

### Patch Changes

- [#3316](https://github.com/PostHog/posthog-js/pull/3316) [`68cd4e5`](https://github.com/PostHog/posthog-js/commit/68cd4e5f1133b95bcb87c382a0ae5f1bcb96903d) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - Fix slim bundle + extension bundles crash caused by inconsistent property mangling
  (2026-04-02)
- Updated dependencies [[`a01a3d5`](https://github.com/PostHog/posthog-js/commit/a01a3d55dc134b1b269be58c7922ce3780c57fc5)]:
    - @posthog/core@1.24.6
    - @posthog/types@1.364.6

---

#### [`@posthog/types@1.364.6`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.364.6)

## 1.364.6

---

#### [`posthog-js@1.364.7`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.364.7)

## 1.364.7

### Patch Changes

- [#3319](https://github.com/PostHog/posthog-js/pull/3319) [`b25b689`](https://github.com/PostHog/posthog-js/commit/b25b68967f7e85317e2aacb8ecc4dc66a95095eb) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - fix: send $groupidentify for new groups even when no properties are provided
  (2026-04-03)
- Updated dependencies []:
    - @posthog/types@1.364.7

---

#### [`@posthog/types@1.364.7`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.364.7)

## 1.364.7

---

#### [`posthog-js@1.365.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.365.0)

## 1.365.0

### Minor Changes

- [#3302](https://github.com/PostHog/posthog-js/pull/3302) [`fc5589f`](https://github.com/PostHog/posthog-js/commit/fc5589fcc51bd53ba818822831867d3c00d83a11) Thanks [@dmarticus](https://github.com/dmarticus)! - preserve $set_once semantics in local flag evaluation cache
  (2026-04-07)

### Patch Changes

- Updated dependencies [[`fc5589f`](https://github.com/PostHog/posthog-js/commit/fc5589fcc51bd53ba818822831867d3c00d83a11)]:
    - @posthog/core@1.25.0
    - @posthog/types@1.365.0

---

#### [`@posthog/types@1.365.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.365.0)

## 1.365.0

---

#### [`posthog-js@1.365.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.365.1)

## 1.365.1

### Patch Changes

- Updated dependencies [[`57ee5b2`](https://github.com/PostHog/posthog-js/commit/57ee5b25fd2c97f334f52b4eba28ea925033d6ed)]:
    - @posthog/core@1.25.1
    - @posthog/types@1.365.1

---

#### [`@posthog/types@1.365.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.365.1)

## 1.365.1

---

#### [`posthog-js@1.365.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.365.2)

## 1.365.2

### Patch Changes

- [#3323](https://github.com/PostHog/posthog-js/pull/3323) [`c387f6d`](https://github.com/PostHog/posthog-js/commit/c387f6dc146c9c09640e471e66043ad832b0476e) Thanks [@pauldambra](https://github.com/pauldambra)! - perf(replay): reduce memory and CPU cost of event compression by caching gzipped empty arrays and eliminating redundant JSON.stringify for size estimation
  (2026-04-08)
- Updated dependencies [[`c387f6d`](https://github.com/PostHog/posthog-js/commit/c387f6dc146c9c09640e471e66043ad832b0476e)]:
    - @posthog/types@1.365.2

---

#### [`@posthog/types@1.365.2`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.365.2)

## 1.365.2

### Patch Changes

- [#3323](https://github.com/PostHog/posthog-js/pull/3323) [`c387f6d`](https://github.com/PostHog/posthog-js/commit/c387f6dc146c9c09640e471e66043ad832b0476e) Thanks [@pauldambra](https://github.com/pauldambra)! - perf(replay): reduce memory and CPU cost of event compression by caching gzipped empty arrays and eliminating redundant JSON.stringify for size estimation
  (2026-04-08)

---

#### [`posthog-js@1.365.3`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.365.3)

## 1.365.3

### Patch Changes

- [#3357](https://github.com/PostHog/posthog-js/pull/3357) [`dbdddca`](https://github.com/PostHog/posthog-js/commit/dbdddcad578adf282f620d2afcd5808600a9c287) Thanks [@pauldambra](https://github.com/pauldambra)! - Bump @posthog/rrweb packages to 0.0.56, which includes:
    - PostHog/posthog-rrweb#157: fix: clear mutation buffer on iframe pagehide to prevent recording corruption
    - PostHog/posthog-rrweb#158: fix: skip unchanged setAttribute calls to prevent replay flicker
    - PostHog/posthog-rrweb#159: fix: prevent iframe leak in untainted prototype and avoid unnecessary iframe creation
    - PostHog/posthog-rrweb#163: fix: handle SecurityError in IframeManager destroy and removeIframeById
    - PostHog/posthog-rrweb#166: fix: remove postcss from @posthog/rrweb-record bundle (420KB → 170KB) (2026-04-08)
- Updated dependencies []:
    - @posthog/types@1.365.3

---

#### [`@posthog/types@1.365.3`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.365.3)

## 1.365.3

---

#### [`posthog-js@1.365.4`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.365.4)

## 1.365.4

### Patch Changes

- [#3353](https://github.com/PostHog/posthog-js/pull/3353) [`3939856`](https://github.com/PostHog/posthog-js/commit/3939856b917a3bad696cb7e5da73d4d50c3e0c53) Thanks [@lucasheriques](https://github.com/lucasheriques)! - Expose the current question index on `.survey-box` via a `data-question-index` attribute. This gives consumers rendering surveys via the API a reliable way to know which question is currently displayed without parsing input ids or class names — works for every question type, including link questions which render no input or rating element.
  (2026-04-08)
- Updated dependencies []:
    - @posthog/types@1.365.4

---

#### [`@posthog/types@1.365.4`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.365.4)

## 1.365.4

---

#### [`posthog-js@1.365.5`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.365.5)

## 1.365.5

### Patch Changes

- Updated dependencies [[`c735b08`](https://github.com/PostHog/posthog-js/commit/c735b08577f8fa85935dcec5bc5814870ac4ed56)]:
    - @posthog/core@1.25.2
    - @posthog/types@1.365.5

---

#### [`@posthog/types@1.365.5`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.365.5)

## 1.365.5

---

#### [`posthog-js@1.366.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.366.0)

## 1.366.0

### Minor Changes

- [#3305](https://github.com/PostHog/posthog-js/pull/3305) [`b599672`](https://github.com/PostHog/posthog-js/commit/b5996729b1d30fb99429c509e6a85ef8d7aca955) Thanks [@veryayskiy](https://github.com/veryayskiy)! - Add customer side identification
  (2026-04-09)

### Patch Changes

- Updated dependencies []:
    - @posthog/types@1.366.0

---

#### [`@posthog/types@1.366.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.366.0)

## 1.366.0

---

#### [`posthog-js@1.366.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.366.1)

## 1.366.1

### Patch Changes

- [#3360](https://github.com/PostHog/posthog-js/pull/3360) [`802bf39`](https://github.com/PostHog/posthog-js/commit/802bf3919304f66694788bf0cb93e457326ab44b) Thanks [@jabahamondes](https://github.com/jabahamondes)! - Re-evaluate consent persistent store when config changes to support cross-subdomain consent sharing
  (2026-04-09)
- Updated dependencies []:
    - @posthog/types@1.366.1

---

#### [`@posthog/types@1.366.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.366.1)

## 1.366.1

---

#### [`posthog-js@1.366.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.366.2)

## 1.366.2

### Patch Changes

- [#3364](https://github.com/PostHog/posthog-js/pull/3364) [`575e354`](https://github.com/PostHog/posthog-js/commit/575e354d0040bd83ac698495a4f0a07dece83eb3) Thanks [@lucasheriques](https://github.com/lucasheriques)! - Add a hover state to numeric survey rating options so they provide clearer pointer feedback before selection.
  (2026-04-09)
- Updated dependencies []:
    - @posthog/types@1.366.2

---

#### [`@posthog/types@1.366.2`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.366.2)

## 1.366.2

---

#### [`posthog-js@1.367.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.367.0)

## 1.367.0

### Minor Changes

- [#3242](https://github.com/PostHog/posthog-js/pull/3242) [`353be9a`](https://github.com/PostHog/posthog-js/commit/353be9a878fe209a032f2d70376ece78ee67303c) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - feat: Add support for pre-loaded remote-config
  (2026-04-09)

### Patch Changes

- Updated dependencies []:
    - @posthog/types@1.367.0

---

#### [`@posthog/types@1.367.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.367.0)

## 1.367.0

---

#### [`posthog-js@1.368.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.368.0)

## 1.368.0

### Minor Changes

- [#3345](https://github.com/PostHog/posthog-js/pull/3345) [`3fcf5c4`](https://github.com/PostHog/posthog-js/commit/3fcf5c449b3fe10ce187d40ea03425de9f94e85f) Thanks [@jonmcwest](https://github.com/jonmcwest)! - Add posthog.captureLog() API for sending structured log entries to PostHog logs
  (2026-04-13)

### Patch Changes

- [#3373](https://github.com/PostHog/posthog-js/pull/3373) [`f5fe0a8`](https://github.com/PostHog/posthog-js/commit/f5fe0a8b11457a33c02029162a43e4eb2d3cb2d9) Thanks [@ksvat](https://github.com/ksvat)! - bump rrweb version
  (2026-04-13)
- Updated dependencies [[`3fcf5c4`](https://github.com/PostHog/posthog-js/commit/3fcf5c449b3fe10ce187d40ea03425de9f94e85f)]:
    - @posthog/types@1.368.0

---

#### [`@posthog/types@1.368.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.368.0)

## 1.368.0

### Minor Changes

- [#3345](https://github.com/PostHog/posthog-js/pull/3345) [`3fcf5c4`](https://github.com/PostHog/posthog-js/commit/3fcf5c449b3fe10ce187d40ea03425de9f94e85f) Thanks [@jonmcwest](https://github.com/jonmcwest)! - Add posthog.captureLog() API for sending structured log entries to PostHog logs
  (2026-04-13)

---

#### [`posthog-js@1.368.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.368.1)

## 1.368.1

### Patch Changes

- [#3379](https://github.com/PostHog/posthog-js/pull/3379) [`d7c71b1`](https://github.com/PostHog/posthog-js/commit/d7c71b1316720d972e41b63987ef57512d615ea7) Thanks [@dmarticus](https://github.com/dmarticus)! - Fix bootstrapped feature flags being overwritten by partial /flags response when `advanced_only_evaluate_survey_feature_flags` is enabled
  (2026-04-14)
- Updated dependencies []:
    - @posthog/types@1.368.1

---

#### [`@posthog/types@1.368.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.368.1)

## 1.368.1

---

#### [`posthog-js@1.368.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.368.2)

## 1.368.2

### Patch Changes

- [#3378](https://github.com/PostHog/posthog-js/pull/3378) [`f1bea33`](https://github.com/PostHog/posthog-js/commit/f1bea33f64800c187f09a0989426ea0e73f43128) Thanks [@marandaneto](https://github.com/marandaneto)! - Disable native gzip compression after a NotReadableError in the browser SDK
  (2026-04-14)
- Updated dependencies []:
    - @posthog/types@1.368.2

---

#### [`@posthog/types@1.368.2`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.368.2)

## 1.368.2

---

#### [`posthog-js@1.369.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.369.0)

## 1.369.0

### Minor Changes

- [#3342](https://github.com/PostHog/posthog-js/pull/3342) [`eea5260`](https://github.com/PostHog/posthog-js/commit/eea5260bbd58fb8b2d7f0550bb03d741aaab376a) Thanks [@ksvat](https://github.com/ksvat)! - Account for property filters on events in recording triggers for v2 triggers
  (2026-04-14)

- [#3281](https://github.com/PostHog/posthog-js/pull/3281) [`b1fd228`](https://github.com/PostHog/posthog-js/commit/b1fd228eab45dc688b769378afa96a0f74167fab) Thanks [@ksvat](https://github.com/ksvat)! - Add session replay trigger groups handling (V2)
  (2026-04-14)

### Patch Changes

- Updated dependencies []:
    - @posthog/types@1.369.0

---

#### [`@posthog/types@1.369.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.369.0)

## 1.369.0

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter posthog-js && npm install`
- Only `package.json` and `package-lock.json` were modified.

🤖 Generated by the `update-deps` skill.
