### PR TITLE
chore: remove duplicated pool option from test:ci script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"npm": "v10"
 	},
 	"scripts": {
-		"test:ci": "vitest run --reporter=default --reporter=junit --coverage --pool=forks --maxWorkers=50%",
+		"test:ci": "vitest run --reporter=default --reporter=junit --coverage --maxWorkers=50%",
 		"test:dev": "vitest run --no-coverage --reporter=default --retry=0",
 		"test": "is-ci && npm run test:ci || npm run test:dev",
 		"test:watch": "vitest --changed",


### PR DESCRIPTION
## Summary
- `pool: 'forks'` was defined both in `vitest.config.ts` (line 50) and as a CLI flag `--pool=forks` in the `test:ci` script in `package.json`
- The CLI flag is redundant since `vitest.config.ts` already applies `pool: 'forks'` to all test runs (CI, dev, watch)
- Removed the duplicated CLI flag to avoid confusion if one value is changed without updating the other

## Test plan
- [x] All 833 tests pass with the change
- [x] Full build (webpack + tsc + api-extractor) succeeds
- [x] Type-check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)