### PR TITLE
chore: use automatic JSX runtime in babel config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
 				ignorePropertyModificationsFor: ['accumulator', 'state', 'event', 'prevState']
 			}
 		],
+		'react/react-in-jsx-scope': 'off',
 		'sonarjs/cognitive-complexity': 'warn',
 		// TODO: enable when this will be released https://github.com/SonarSource/eslint-plugin-sonarjs/pull/405
 		'sonarjs/no-duplicate-string': 'off',

--- a/api-extractor/carbonio-shell-ui.api.md
+++ b/api-extractor/carbonio-shell-ui.api.md
@@ -159,12 +159,12 @@ type AppActions = {
 // Warning: (ae-forgotten-export) The symbol "AppContextProviderProps" needs to be exported by the entry point lib.d.ts
 //
 // @public
-export const AppContextProvider: (input: AppContextProviderProps) => React_2.JSX.Element;
+export const AppContextProvider: (input: AppContextProviderProps) => React.JSX.Element;
 
 // @public (undocumented)
 interface AppContextProviderProps {
     // (undocumented)
-    children: React_2.ReactNode | React_2.ReactNode[];
+    children: React.ReactNode | React.ReactNode[];
     // (undocumented)
     pkg: string;
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -19,7 +19,7 @@ module.exports = (api) => {
 	return {
 		presets: [
 			['@babel/preset-env', { useBuiltIns: 'usage', corejs: 3.49, ...presetEnvOptions }],
-			'@babel/preset-react',
+			['@babel/preset-react', { runtime: 'automatic' }],
 			'@babel/preset-typescript'
 		],
 		plugins

--- a/src/boot/app/app-context-provider.tsx
+++ b/src/boot/app/app-context-provider.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import { AppErrorCatcher } from './app-error-catcher';
 import { ModuleI18nextProvider } from '../module-i18next-provider';
 

--- a/src/boot/app/default-views.test.tsx
+++ b/src/boot/app/default-views.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { produce } from 'immer';
 
 import { DefaultViewsRegister } from './default-views';

--- a/src/boot/loader.test.tsx
+++ b/src/boot/loader.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { act, waitFor } from '@testing-library/react';
 import type { AccountSettingsPrefs } from '@zextras/carbonio-ui-soap-lib';
 import { api, ApiEvents } from '@zextras/carbonio-ui-soap-lib';

--- a/src/boot/module-i18next-provider.tsx
+++ b/src/boot/module-i18next-provider.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import { I18nextProvider } from 'react-i18next';
 
 import { SHELL_APP_ID } from '../constants';

--- a/src/boot/shell-i18n-provider.tsx
+++ b/src/boot/shell-i18n-provider.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import { I18nextProvider } from 'react-i18next';
 
 import { SHELL_APP_ID } from '../constants';

--- a/src/boot/splash.tsx
+++ b/src/boot/splash.tsx
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import './splash.css';
-import React from 'react';
 
-export const LoadingView = (): React.JSX.Element => (
+import './splash.css';
+
+export const LoadingView = (): JSX.Element => (
 	<div className="splash">
 		<div className="loader">
 			<div className="bar"></div>

--- a/src/boot/use-get-primary-color.test.tsx
+++ b/src/boot/use-get-primary-color.test.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import { act, screen } from '@testing-library/react';
 import { produce } from 'immer';
 

--- a/src/settings/accounts-settings.test.tsx
+++ b/src/settings/accounts-settings.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { faker } from '@faker-js/faker';
 import { act, screen, waitFor, within } from '@testing-library/react';
 import { head, shuffle, tail } from 'lodash';

--- a/src/settings/components/general-settings/out-of-office-settings.test.tsx
+++ b/src/settings/components/general-settings/out-of-office-settings.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { faker } from '@faker-js/faker';
 import { act, screen, within } from '@testing-library/react';
 import type { AccountSettingsPrefs } from '@zextras/carbonio-ui-soap-lib';

--- a/src/settings/components/general-settings/out-of-office-time-period-section.test.tsx
+++ b/src/settings/components/general-settings/out-of-office-time-period-section.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { faker } from '@faker-js/faker';
 import { act, screen } from '@testing-library/react';
 import { format, addDays, subDays, startOfDay, endOfDay, addHours, subHours } from 'date-fns';

--- a/src/settings/components/general-settings/privacy.test.tsx
+++ b/src/settings/components/general-settings/privacy.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { Privacy } from './privacy';
 import { ICONS } from '../../../tests/constants';
 import { screen, setup } from '../../../tests/utils';

--- a/src/settings/components/general-settings/search-settings.test.tsx
+++ b/src/settings/components/general-settings/search-settings.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { act, screen } from '@testing-library/react';
 import type { AccountSettingsPrefs } from '@zextras/carbonio-ui-soap-lib';
 

--- a/src/settings/components/general-settings/settings-section.tsx
+++ b/src/settings/components/general-settings/settings-section.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import { FormSection } from '@zextras/carbonio-design-system';
 
 import type { SettingsSubSection } from '../../../types/apps';

--- a/src/settings/components/general-settings/user-quota.test.tsx
+++ b/src/settings/components/general-settings/user-quota.test.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import { faker } from '@faker-js/faker';
 import type { QuotaProps } from '@zextras/carbonio-design-system';
 import { produce } from 'immer';

--- a/src/settings/general-settings.test.tsx
+++ b/src/settings/general-settings.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { faker } from '@faker-js/faker';
 import { screen, waitFor, within } from '@testing-library/react';
 import type { AccountSettingsPrefs } from '@zextras/carbonio-ui-soap-lib';

--- a/src/settings/settings-app-view.test.tsx
+++ b/src/settings/settings-app-view.test.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import { SettingsAppView } from './settings-app-view';
 import { useAppStore } from '../store/app';
 import { screen, setup } from '../tests/utils';

--- a/src/settings/settings-sidebar.test.tsx
+++ b/src/settings/settings-sidebar.test.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import { screen } from '@testing-library/react';
 import { useNavigate } from 'react-router-dom';
 import type { Mock } from 'vitest';

--- a/src/shell/badge-wrap.tsx
+++ b/src/shell/badge-wrap.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import styled from '@emotion/styled';
 import { Container, Badge, Icon, Tooltip } from '@zextras/carbonio-design-system';
 

--- a/src/shell/boards/board-container.test.tsx
+++ b/src/shell/boards/board-container.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { act, screen, waitFor, within } from '@testing-library/react';
 import { Input } from '@zextras/carbonio-design-system';
 import { reduce, sample, size } from 'lodash';

--- a/src/shell/boards/board-tab-list.test.tsx
+++ b/src/shell/boards/board-tab-list.test.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import { screen, within } from '@testing-library/react';
 
 import { TabsList } from './board-tab-list';

--- a/src/shell/boards/board-tab-list.tsx
+++ b/src/shell/boards/board-tab-list.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import styled from '@emotion/styled';
 import { Row } from '@zextras/carbonio-design-system';
 import { isEmpty, map } from 'lodash';

--- a/src/shell/collapser.tsx
+++ b/src/shell/collapser.tsx
@@ -5,7 +5,6 @@
  */
 
 import type { FunctionComponent } from 'react';
-import React from 'react';
 
 import styled from '@emotion/styled';
 import { Icon } from '@zextras/carbonio-design-system';

--- a/src/shell/logo.tsx
+++ b/src/shell/logo.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { useLogo } from '../store/login/hooks';
 import { useLoginConfigStore } from '../store/login/store';
 

--- a/src/shell/shell-header.test.tsx
+++ b/src/shell/shell-header.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import ShellHeader from './shell-header';
 import { useIntegrationsStore } from '../store/integrations/store';
 import { setup, screen } from '../tests/utils';

--- a/src/shell/shell-header.tsx
+++ b/src/shell/shell-header.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import styled from '@emotion/styled';
 import { Catcher, Container, Padding } from '@zextras/carbonio-design-system';
 import type { SearchBar as SearchUISearchBar } from '@zextras/carbonio-search-ui';

--- a/src/shell/shell-primary-bar.test.tsx
+++ b/src/shell/shell-primary-bar.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { act } from '@testing-library/react';
 import { Button, Text } from '@zextras/carbonio-design-system';
 import { produce } from 'immer';

--- a/src/shell/shell-secondary-bar.test.tsx
+++ b/src/shell/shell-secondary-bar.test.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import ShellSecondaryBar from './shell-secondary-bar';
 import { useAppStore } from '../store/app';
 import { setup, screen } from '../tests/utils';

--- a/src/shell/shell-view.test.tsx
+++ b/src/shell/shell-view.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { act, screen, waitFor } from '@testing-library/react';
 
 import { BOARD_DEFAULT_POSITION } from './boards/board-container';

--- a/src/store/app/utils.tsx
+++ b/src/store/app/utils.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import { trim } from 'lodash';
 
 import type {

--- a/src/store/integrations/utils.tsx
+++ b/src/store/integrations/utils.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { compact, map } from 'lodash';
 
 import type { IntegrationsState } from './store';

--- a/src/store/login/hooks.test.tsx
+++ b/src/store/login/hooks.test.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import { act, renderHook } from '@testing-library/react';
 
 import { useIsCarbonioCE } from './hooks';

--- a/src/tests/test-app-utils.tsx
+++ b/src/tests/test-app-utils.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { faker } from '@faker-js/faker';
 
 import { useAppStore } from '../store/app';

--- a/src/tracker/page-view.test.tsx
+++ b/src/tracker/page-view.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { Link } from 'react-router-dom';
 
 import { TrackerPageView } from './page-view';

--- a/src/tracker/provider.test.tsx
+++ b/src/tracker/provider.test.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React from 'react';
-
 import { PostHogProvider } from 'posthog-js/react';
 import type * as PostHogReact from 'posthog-js/react';
 

--- a/src/ui-extras/auth-guard.test.tsx
+++ b/src/ui-extras/auth-guard.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { AuthGuard } from './auth-guard';
 import * as accountStoreHooks from '../store/account/hooks';
 import { setup, screen } from '../tests/utils';

--- a/src/ui-extras/auth-guard.tsx
+++ b/src/ui-extras/auth-guard.tsx
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import { useAuthenticated } from '../store/account';
 

--- a/src/utility-bar/bar.test.tsx
+++ b/src/utility-bar/bar.test.tsx
@@ -3,8 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
-
 import { act, waitFor } from '@testing-library/react';
 import { api } from '@zextras/carbonio-ui-soap-lib';
 

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,30 +1,15 @@
 {
-  "extends": "@tsconfig/node22/tsconfig.json",
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "lib": [
-      "DOM",
-      "es2023"
-    ],
-    "jsx": "react",
-    "declaration": true,
-    "sourceMap": true,
-    "declarationMap": false,
-    "outDir": "lib",
-    "types": [
-      "./src/i18next.d.ts",
-      "./src/assets.d.ts",
-      "./src/globals.d.ts",
-      "node"
-    ]
-  },
-  "files": [
-    "src/lib.ts",
-    "src/testing.ts",
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "lib"
-  ]
+	"extends": "@tsconfig/node22/tsconfig.json",
+	"compilerOptions": {
+		"resolveJsonModule": true,
+		"lib": ["DOM", "es2023"],
+		"jsx": "react-jsx",
+		"declaration": true,
+		"sourceMap": true,
+		"declarationMap": false,
+		"outDir": "lib",
+		"types": ["./src/i18next.d.ts", "./src/assets.d.ts", "./src/globals.d.ts", "node"]
+	},
+	"files": ["src/lib.ts", "src/testing.ts"],
+	"exclude": ["node_modules", "dist", "lib"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,9 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+	esbuild: {
+		jsx: 'automatic'
+	},
 	css: {
 		postcss: {}
 	},


### PR DESCRIPTION
## Summary
- Switch `@babel/preset-react` to `runtime: 'automatic'` — the modern JSX transform introduced in React 17
- Configure `esbuild jsx: 'automatic'` in `vitest.config.ts` so tests use the same transform
- Update `tsconfig.lib.json` `jsx` from `'react'` to `'react-jsx'` to align the library build
- Disable ESLint `react/react-in-jsx-scope` rule (no longer needed with automatic runtime)
- Remove `import React from 'react'` from 37 files where it was only required for the classic JSX transform
  - Kept in `shared-libraries.ts` where React is used as a runtime value
- Updated `api-extractor` report (cosmetic: `React_2` aliases become `React`)

## Why

The new JSX transform (`runtime: 'automatic'`) was introduced in 2020 with React 17 and is the recommended approach since then. According to the [official React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-jsx-transform-is-now-required):

> A new JSX transform, introduced in 2020, improved bundle size and allowed JSX use without importing React. React 19 adds further improvements, such as using `ref` as a prop and JSX speed enhancements, **which require this new transform**. If the new transform is not enabled, a warning will appear.

While the project currently uses React 18 (so it's not yet mandatory), adopting the automatic runtime now:
- Aligns with the recommended best practice
- Prepares the codebase for a future React 19 migration
- Removes boilerplate `import React` from 37 files
- Produces a slightly smaller bundle (the `react/jsx-runtime` module is more optimized than `React.createElement`)

## Test plan
- [x] All 833 tests pass (0 retry)
- [x] Full webpack build succeeds
- [x] Library build (tsc + api-extractor) succeeds
- [x] Type-check passes
- [x] Lint passes (0 errors)
- [x] REUSE compliance passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)