### PR TITLE
chore(deps): bump posthog-js from 1.369.1 to 1.369.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"i18next-http-backend": "2.7.3",
 				"immer": "10.2.0",
 				"lodash": "4.18.1",
-				"posthog-js": "1.369.1",
+				"posthog-js": "1.369.2",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-i18next": "^12.3.1",
@@ -4712,9 +4712,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@posthog/types": {
-			"version": "1.369.1",
-			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.369.1.tgz",
-			"integrity": "sha512-5sUMa/gmGloazdnDZF8hfzMhGAhxtuTy3v7plnx+mR72fjDyg0aUQjmCeoxxyFOrBAO5aVYxESxPVKJepE6EfA==",
+			"version": "1.369.2",
+			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.369.2.tgz",
+			"integrity": "sha512-PJqkqPCFnnbCZslH2jHSvXlasRqvke6YAsYPhPALy4zy2hldor8A0O2wIlpAefEJ7fVz6wR5ZbRJzQP6nwujyw==",
 			"license": "MIT"
 		},
 		"node_modules/@protobufjs/aspromise": {
@@ -16023,9 +16023,9 @@
 			"license": "MIT"
 		},
 		"node_modules/posthog-js": {
-			"version": "1.369.1",
-			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.369.1.tgz",
-			"integrity": "sha512-xerj/T3NE65H9cqUKzg2LbNmavTC/qr26CnE+yBw+yNyro6Fmvs9+CMvRc2+RkDsoOdSmrq9cwR9noZqfjC2Kg==",
+			"version": "1.369.2",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.369.2.tgz",
+			"integrity": "sha512-pY+SvNvRp3C2XW80h/jwVLTgoruK15C6klo9bYYoO6DCK9EbcwS6YzjgxBHx1dIN0XBZM3KWJPmuaSimU65HQQ==",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",
@@ -16034,7 +16034,7 @@
 				"@opentelemetry/resources": "^2.2.0",
 				"@opentelemetry/sdk-logs": "^0.208.0",
 				"@posthog/core": "1.25.2",
-				"@posthog/types": "1.369.1",
+				"@posthog/types": "1.369.2",
 				"core-js": "^3.38.1",
 				"dompurify": "^3.3.2",
 				"fflate": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
 		"i18next-http-backend": "2.7.3",
 		"immer": "10.2.0",
 		"lodash": "4.18.1",
-		"posthog-js": "1.369.1",
+		"posthog-js": "1.369.2",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-i18next": "^12.3.1",


### PR DESCRIPTION
## Bump `posthog-js` from `1.369.1` to `1.369.2`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `1.369.1`
- **New:** `1.369.2`
- **npm:** https://www.npmjs.com/package/posthog-js/v/1.369.2

### Changelog


#### [`posthog-js@1.369.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.369.2)

## 1.369.2

### Patch Changes

- [#3386](https://github.com/PostHog/posthog-js/pull/3386) [`4a65604`](https://github.com/PostHog/posthog-js/commit/4a65604775fe87c47e5fbdb5f03673f2481c26ea) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - Add a preview flag for versioned browser lazy bundle asset paths.
  (2026-04-16)
- Updated dependencies [[`4a65604`](https://github.com/PostHog/posthog-js/commit/4a65604775fe87c47e5fbdb5f03673f2481c26ea)]:
    - @posthog/types@1.369.2

---

#### [`@posthog/types@1.369.2`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.369.2)

## 1.369.2

### Patch Changes

- [#3386](https://github.com/PostHog/posthog-js/pull/3386) [`4a65604`](https://github.com/PostHog/posthog-js/commit/4a65604775fe87c47e5fbdb5f03673f2481c26ea) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - Add a preview flag for versioned browser lazy bundle asset paths.
  (2026-04-16)

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter posthog-js && npm install`
- Only `package.json` and `package-lock.json` were modified.

🤖 Generated by the `update-deps` skill.
