### PR TITLE
build(release): update jenkins-lib-ui to 1.0.12

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-ui@CD-test',
+    identifier: 'jenkins-lib-ui@1.0.12',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
## Summary
- Update `jenkins-lib-ui` identifier from `@CD-test` to `@1.0.12` in `Jenkinsfile`

Closes CO-3547