### PR TITLE
fix(ci): migrate Jenkinsfile to jenkins-lib-common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ src/constants/locales.js
 *.tgz
 *.DS_Store
 /.claude/
+/.worktrees/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-ui@1.0.13',
+    identifier: 'jenkins-lib-common@v2.4.3',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',
-        remote: 'git@github.com:zextras/jenkins-lib-ui.git',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
     ])
 )
 
 withCredentials([string(credentialsId: 'posthog-api-token', variable: 'POSTHOG_API_KEY')]) {
-    zappPipeline()
+    uiPipeline()
 }


### PR DESCRIPTION
## Summary

`jenkins-lib-ui` has been consolidated into `jenkins-lib-common`. The `uiPipeline()` function is now available directly from `jenkins-lib-common` starting from version `v2.4.3`.

### Changes

- Replaced `jenkins-lib-ui@1.0.13` library reference with `jenkins-lib-common@v2.4.3`
- Updated the remote URL from `jenkins-lib-ui.git` to `jenkins-lib-common.git`
- Renamed `zappPipeline()` call to `uiPipeline()` (parameters unchanged)

### References

- `jenkins-lib-ui` is now merged into `jenkins-lib-common` — no further updates will be published to the old library
- `uiPipeline()` in `jenkins-lib-common@v2.4.3` is a drop-in replacement for `zappPipeline()` in `jenkins-lib-ui`