### PR TITLE
fix(i18n): available languages

### DIFF
--- a/src/constants/default-locales.ts
+++ b/src/constants/default-locales.ts
@@ -13,12 +13,6 @@ type LocaleValue = {
 };
 
 export const STATIC_LOCALES: Record<string, LocaleValue> = {
-	zh_CN: {
-		name: '中文 (中国)',
-		value: 'zh_CN',
-		labelKey: 'locale.label_chinese',
-		labelDefaultValue: 'Chinese (China) - {{value}}'
-	},
 	nl: {
 		name: 'Nederlands',
 		value: 'nl',
@@ -120,6 +114,12 @@ export const STATIC_LOCALES: Record<string, LocaleValue> = {
 		value: 'ky',
 		labelKey: 'locale.label_kyrgyz',
 		labelDefaultValue: 'Kyrgyz - {{value}}'
+	},
+	id: {
+		name: 'Bahasa Indonesia',
+		value: 'id',
+		labelKey: 'locale.label_indonesian',
+		labelDefaultValue: 'Indonesian - {{value}}'
 	},
 	bs: {
 		name: 'Bosanski',

--- a/src/constants/locales.ts
+++ b/src/constants/locales.ts
@@ -118,6 +118,12 @@ export const DATE_FNS_LOCALE: Record<
 			)
 	},
 	ky: undefined,
+	id: {
+		localeImportPath: () =>
+			/* webpackMode: "lazy", webpackChunkName: "id" */ import('date-fns/locale/id').then(
+				({ id }) => id
+			)
+	},
 	bs: {
 		localeImportPath: () =>
 			/* webpackMode: "lazy", webpackChunkName: "bs" */ import('date-fns/locale/bs').then(


### PR DESCRIPTION
Based on [available languages](https://docs.zextras.com/carbonio/html/basics/general.html#available-languages):
- Removed `Chinese (China) - 中文 (中国)`.
- Introduced `Indonesian - Bahasa Indonesia`.


Ref: CO-3341