### PR TITLE
chore(deps): bump @faker-js/faker from 9.9.0 to 10.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"@commitlint/types": "20.5.0",
 		"@emotion/babel-plugin": "11.13.5",
 		"@emotion/jest": "11.14.2",
-		"@faker-js/faker": "9.9.0",
+		"@faker-js/faker": "10.4.0",
 		"@microsoft/api-extractor": "7.58.2",
 		"@semantic-release/changelog": "6.0.3",
 		"@semantic-release/commit-analyzer": "13.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: 11.14.2
         version: 11.14.2
       '@faker-js/faker':
-        specifier: 9.9.0
-        version: 9.9.0
+        specifier: 10.4.0
+        version: 10.4.0
       '@microsoft/api-extractor':
         specifier: 7.58.2
         version: 7.58.2(@types/node@22.19.17)
@@ -1225,9 +1225,9 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@faker-js/faker@9.9.0':
-    resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
-    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
+  '@faker-js/faker@10.4.0':
+    resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -8440,7 +8440,7 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@faker-js/faker@9.9.0': {}
+  '@faker-js/faker@10.4.0': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:


### PR DESCRIPTION
## Summary

| Package | Bucket | Old → New | Bump | Package manager |
|---|---|---|---|---|
| `@faker-js/faker` | devDependencies | `9.9.0` → `10.4.0` | major | pnpm |

## Breaking changes (v10) — impact on this codebase

All breaking changes from `@faker-js/faker` v10 were verified against the project's faker usage (9 test files only, default English locale, no constrained queries). No code edits were required.

| Breaking change | Status |
|---|---|
| ESM-only (with Node `require(esm)` shim) | Safe — used only in Vitest tests (ESM-native), engines `node: v22` ≥ 22.13 |
| Removed v9 deprecations (`faker.address.*`, `faker.name.*`, etc.) | Safe — codebase already uses `faker.person.*`; no `address`/`name` calls |
| `faker.word.*` default error strategy → `'fail'` | Safe — `word.noun()` and `word.sample()` invoked without length constraints |
| Removed invalid credit card issuer patterns | Safe — `faker.finance.*` is not used |

faker APIs in use (all stable in v10): `commerce.product*`, `date.*`, `lorem.*`, `number.int`, `person.*`, `string.*`, `word.noun`, `word.sample`.

## Verification

- `pnpm type-check` — passed
- `pnpm lint` — passed
- `pnpm test` — passed (854 tests across 38 files)
- `pnpm build` — passed

Pre-commit hook re-ran `type-check`, `lint`, `test` on commit; all green.

## Context7 sources consulted

- Library id: `/faker-js/faker`
- Question: *"migration from v9 to v10, breaking changes, removed deprecated APIs, ESM only"* — confirmed all breaking changes from the upstream v10 migration guide.

## Changelog

#### [`v10.0.0`](https://github.com/faker-js/faker/releases/tag/v10.0.0)

## New & Noteworthy

- esm only (for cjs support look into migration guide, we got you covered)
- remove v9 deprecations
- change default error strategy to 'fail' in word module
- remove invalid credit card issuer patterns
- see our [migration guide](https://v10.fakerjs.dev/guide/upgrading.html)

## What's Changed
* ci: use node 24 by @Shinigami92 in https://github.com/faker-js/faker/pull/3543
* infra: stop using node 18 by @Shinigami92 in https://github.com/faker-js/faker/pull/3536
* infra: use import.meta.dirname by @Shinigami92 in https://github.com/faker-js/faker/pull/3542
* feat!: esm only by @Shinigami92 in https://github.com/faker-js/faker/pull/3540
* refactor!: remove deprecations by @Shinigami92 in https://github.com/faker-js/faker/pull/3553
* docs: migration guide for v10 by @matthewmayer in https://github.com/faker-js/faker/pull/3559
* infra: more precise engines field by @matthewmayer in https://github.com/faker-js/faker/pull/3561
* refactor(word)!: change default error strategy to 'fail' by @xDivisionByZerox in https://github.com/faker-js/faker/pull/3560
* refactor(locale): remove invalid credit card issuer patterns by @xDivisionByZerox in https://github.com/faker-js/faker/pull/3568

**Full Changelog**: https://github.com/faker-js/faker/compare/v9.9.0...v10.0.0

---

#### [`v10.1.0`](https://github.com/faker-js/faker/releases/tag/v10.1.0)

* refactor(image): mark loremflickr as deprecated, use only picsum photos in url()
* fix(locale): fix the Spring Airlines IATA Code
* feat(locale): Add ku_ckb locale
* feat(locale): add Russian localization for book module

**Full Changelog**: https://github.com/faker-js/faker/compare/v10.0.0...v10.1.0

---

#### [`v10.2.0`](https://github.com/faker-js/faker/releases/tag/v10.2.0)

Locale additions (`id_ID`, `bn_BD`, `hu`, `ku_ckb`, `sl_SI`, `nb_NO`, `ku_kmr_latin`, `da`); `feat(commerce): allow for locale-specific product name patterns`; `feat(finance): add IR iban`; `feat: Add support for UPC`; cleanup of inappropriate words from `ja` locale.

**Full Changelog**: https://github.com/faker-js/faker/compare/v10.1.0...v10.2.0

---

#### [`v10.3.0`](https://github.com/faker-js/faker/releases/tag/v10.3.0)

* `feat(person): sexType can return 'generic'`
* `feat(string): support uuid v7`
* Japanese definitions added for suffix, job, food, color, internet, dog
* Norwegian (nb_NO) zodiac sign, sex, direction, continent, vehicle definitions

**Full Changelog**: https://github.com/faker-js/faker/compare/v10.2.0...v10.3.0

---

#### [`v10.4.0`](https://github.com/faker-js/faker/releases/tag/v10.4.0)

* `feat(food): add plant-based dish variety`
* `feat: fi locale phone numbers`
* `refactor(hacker): use helpers.fake() instead of helpers.mustache() in phrase()`
* Japanese cat/cattle/bear/bird/fish/horse breed definitions
* Norwegian (nb_NO) country definition; `fix(locales)`: typos in `es_MX` street names

**Full Changelog**: https://github.com/faker-js/faker/compare/v10.3.0...v10.4.0
