### PR TITLE
chore(deps): bump i18next-http-backend from 3.0.5 to 3.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
 		"date-fns": "4.1.0",
 		"i18next": "22.5.1",
 		"i18next-chained-backend": "4.6.3",
-		"i18next-http-backend": "3.0.5",
+		"i18next-http-backend": "3.0.6",
 		"immer": "10.2.0",
 		"lodash": "4.18.1",
 		"posthog-js": "1.369.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: 4.6.3
         version: 4.6.3
       i18next-http-backend:
-        specifier: 3.0.5
-        version: 3.0.5
+        specifier: 3.0.6
+        version: 3.0.6
       immer:
         specifier: 10.2.0
         version: 10.2.0
@@ -4512,8 +4512,8 @@ packages:
   i18next-chained-backend@4.6.3:
     resolution: {integrity: sha512-Yg4hAKg/98zRAMQs87vJSNevTzaPPrYF3Eb7Kpx+UEaaXLd3p69g7dulAL+hpmZQHeMQ/5gFqHVtdwva53mB0Q==}
 
-  i18next-http-backend@3.0.5:
-    resolution: {integrity: sha512-QaWHnsxieEDcqKe+vo/RFqpiIFRi/KBqlOSPcUlvinBaISCeiTRCbtrazHAjtHtsLC66oDsROAH8frWkQzfMMQ==}
+  i18next-http-backend@3.0.6:
+    resolution: {integrity: sha512-mBOqy8993jtqAoj6XaI1XeC/8/9v6EPS+681ziegrPvTB0DoaCY7PpTS0SpY56qLMoS4OI1TZEM2Zf59zNh05w==}
 
   i18next@22.5.1:
     resolution: {integrity: sha512-8TGPgM3pAD+VRsMtUMNknRz3kzqwp/gPALrWMsDnmC1mKqJwpWyooQRLMcbTwq8z8YwSmuj+ZYvc+xCuEpkssA==}
@@ -12125,7 +12125,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
 
-  i18next-http-backend@3.0.5:
+  i18next-http-backend@3.0.6:
     dependencies:
       cross-fetch: 4.1.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Bump `i18next-http-backend` from `3.0.5` to `3.0.6`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `3.0.5`
- **New:** `3.0.6`
- **npm:** https://www.npmjs.com/package/i18next-http-backend/v/3.0.6

### Changelog

#### 3.0.6

- fix: allow forward slashes in `ns` values so nested namespace names (mapping to URL layouts such as `/locales/en/a/b.json`) fetch correctly again. 3.0.5's security fix applied the same strict URL-segment check to both `lng` and `ns`, which was correct for `lng` (no BCP-47 shape contains `/`) but over-strict for `ns` — nested namespaces containing `/` were never officially supported, but the behaviour fell out of the implicit string-substitution semantics of `loadPath` and is common enough in the wild to be worth accommodating. `isSafeUrlSegment` is now split into `isSafeLangUrlSegment` (strict — still rejects `/`) and `isSafeNsUrlSegment` (loose — allows `/` but still rejects `..`, `\`, URL-structure characters, control chars, prototype keys, and oversized inputs). `isSafeUrlSegment` is kept as a backwards-compatible alias for the strict check. The 3.0.5 security fix remains in force for every concrete attack pattern from the original advisory.


_Source: [CHANGELOG.md](https://github.com/i18next/i18next-http-backend/blob/HEAD/CHANGELOG.md)_

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter i18next-http-backend && pnpm install`
- Only `package.json` and `pnpm-lock.yaml` were modified.

🤖 Generated by the `update-deps` skill.
