### PR TITLE
chore(deps): bump darkreader from 4.9.120 to 4.9.125

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 		"@zextras/carbonio-design-system": "12.0.2",
 		"@zextras/carbonio-ui-preview": "5.0.0",
 		"@zextras/carbonio-ui-soap-lib": "1.2.0",
-		"darkreader": "4.9.120",
+		"darkreader": "4.9.125",
 		"date-fns": "4.1.0",
 		"i18next": "22.5.1",
 		"i18next-chained-backend": "4.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 1.2.0
         version: 1.2.0
       darkreader:
-        specifier: 4.9.120
-        version: 4.9.120
+        specifier: 4.9.125
+        version: 4.9.125
       date-fns:
         specifier: 4.1.0
         version: 4.1.0
@@ -1889,8 +1889,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.56.0':
-    resolution: {integrity: sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==}
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -1932,8 +1932,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.56.0':
-    resolution: {integrity: sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==}
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
 
@@ -3496,8 +3496,8 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
-  darkreader@4.9.120:
-    resolution: {integrity: sha512-BYjP9rsFzwtO2KDXfzqGZHBfo9LAp7azyRR4UIj0/n8uls0C0J08Rhh5g05BZU/CARvDmMf+LQXM9PoPxO1M4A==}
+  darkreader@4.9.125:
+    resolution: {integrity: sha512-ImuQiS+KP0HAvW8GllH+Yy3UYZYfdS/nHM/8MVh7/14g+GoJzm/Cq6dYsRpo+cLW68udXDMtoaHrsOrbBFEh9Q==}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -9035,7 +9035,7 @@ snapshots:
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.56.0':
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
@@ -9059,7 +9059,7 @@ snapshots:
   '@rollup/rollup-win32-x64-gnu@4.60.4':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.56.0':
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.60.4':
@@ -9992,7 +9992,7 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
       '@floating-ui/dom': 1.7.6
       core-js: 3.49.0
-      darkreader: 4.9.120
+      darkreader: 4.9.125
       date-fns: 4.1.0
       lodash: 4.18.1
       polished: 4.3.1
@@ -10906,12 +10906,12 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
-  darkreader@4.9.120:
+  darkreader@4.9.125:
     dependencies:
       malevic: 0.20.2
     optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu': 4.56.0
-      '@rollup/rollup-win32-x64-msvc': 4.56.0
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
 
   data-urls@7.0.0:
     dependencies:


### PR DESCRIPTION
## Bump `darkreader` from `4.9.120` to `4.9.125`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `4.9.120`
- **New:** `4.9.125`
- **npm:** https://www.npmjs.com/package/darkreader/v/4.9.125

### Changelog


#### [`v4.9.121`](https://github.com/darkreader/darkreader/releases/tag/v4.9.121)

_No substantive changes after noise filtering._

---

#### [`v4.9.122`](https://github.com/darkreader/darkreader/releases/tag/v4.9.122)

_No substantive changes after noise filtering._

---

#### [`v4.9.123`](https://github.com/darkreader/darkreader/releases/tag/v4.9.123)

_No substantive changes after noise filtering._

---

#### [`v4.9.124`](https://github.com/darkreader/darkreader/releases/tag/v4.9.124)

_No substantive changes after noise filtering._

---

#### [`v4.9.125`](https://github.com/darkreader/darkreader/releases/tag/v4.9.125)

_No substantive changes after noise filtering._

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter darkreader && pnpm install`
- Only `package.json` and `pnpm-lock.yaml` were modified.

🤖 Generated by the `update-deps` skill.
