### PR TITLE
chore(deps): bump posthog-js from 1.369.2 to 1.379.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"i18next-http-backend": "3.0.5",
 		"immer": "10.2.0",
 		"lodash": "4.18.1",
-		"posthog-js": "1.369.2",
+		"posthog-js": "1.379.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
 		"react-i18next": "12.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: 4.18.1
         version: 4.18.1
       posthog-js:
-        specifier: 1.369.2
-        version: 1.369.2
+        specifier: 1.379.0
+        version: 1.379.0
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -1753,11 +1753,11 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@posthog/core@1.25.2':
-    resolution: {integrity: sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==}
+  '@posthog/core@1.30.3':
+    resolution: {integrity: sha512-mGIN4Du1a8fKxV5WfnEtogq3VOQLa4PfWMUg5uMIMDD+fp5bhTA4QG4oYAea4vBTZ1ZOanQbjXcX4b5k2X93Qw==}
 
-  '@posthog/types@1.369.2':
-    resolution: {integrity: sha512-PJqkqPCFnnbCZslH2jHSvXlasRqvke6YAsYPhPALy4zy2hldor8A0O2wIlpAefEJ7fVz6wR5ZbRJzQP6nwujyw==}
+  '@posthog/types@1.379.0':
+    resolution: {integrity: sha512-QJLzyV22iZKy5eEXKn9IB1swSVo2JigIawebBha+BmsePsY3XA0HAcq2B+D8Km5BHnbE+SGm5aHxFG3DlVE1yg==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -5753,8 +5753,8 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.369.2:
-    resolution: {integrity: sha512-pY+SvNvRp3C2XW80h/jwVLTgoruK15C6klo9bYYoO6DCK9EbcwS6YzjgxBHx1dIN0XBZM3KWJPmuaSimU65HQQ==}
+  posthog-js@1.379.0:
+    resolution: {integrity: sha512-cSESmnPvIaY/pyhV5a6pF00q8tqmXlJBQWX9T7dbBh9TXhVM5oQVi7g77vWGD9G8wq4iNF5ZOxqeAK9dpOSOYg==}
 
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
@@ -8956,9 +8956,11 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@posthog/core@1.25.2': {}
+  '@posthog/core@1.30.3':
+    dependencies:
+      '@posthog/types': 1.379.0
 
-  '@posthog/types@1.369.2': {}
+  '@posthog/types@1.379.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -13256,15 +13258,15 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.369.2:
+  posthog-js@1.379.0:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.208.0
       '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
-      '@posthog/core': 1.25.2
-      '@posthog/types': 1.369.2
+      '@posthog/core': 1.30.3
+      '@posthog/types': 1.379.0
       core-js: 3.49.0
       dompurify: 3.4.6
       fflate: 0.4.8


### PR DESCRIPTION
## Bump `posthog-js` from `1.369.2` to `1.379.0`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `1.369.2`
- **New:** `1.379.0`
- **Minor jump:** +10
- **npm:** https://www.npmjs.com/package/posthog-js/v/1.379.0

### ⚠️ High-risk minor jump

> This bump crosses 10 minor versions. Check the release notes below carefully for behavioral changes.

### Changelog


#### [`posthog-js@1.369.3`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.369.3)

## 1.369.3

### Patch Changes

- [#3419](https://github.com/PostHog/posthog-js/pull/3419) [`ea08727`](https://github.com/PostHog/posthog-js/commit/ea087272bbe210e5610c9271aa1194776e927353) Thanks [@haacked](https://github.com/haacked)! - Reinstate `$feature_flag_payloads` and `$surveys_activated` in captured event properties.
  (2026-04-18)

- [#3416](https://github.com/PostHog/posthog-js/pull/3416) [`3d8b2e2`](https://github.com/PostHog/posthog-js/commit/3d8b2e282927d0c09670b3f112c7dc159cebf059) Thanks [@feliperalmeida](https://github.com/feliperalmeida)! - Updated dependencies: - protobufjs@7.5.5
- Updated dependencies []:
    - @posthog/types@1.369.3

---

#### [`@posthog/types@1.369.3`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.369.3)

## 1.369.3

---

#### [`posthog-js@1.369.4`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.369.4)

## 1.369.4

### Patch Changes

- [#3362](https://github.com/PostHog/posthog-js/pull/3362) [`d61bce1`](https://github.com/PostHog/posthog-js/commit/d61bce11b4bd3abe95bcc76960bde585945a7edc) Thanks [@sampennington](https://github.com/sampennington)! - fix(cookieless): start in cookieless mode when opt_out_capturing_by_default is set
  (2026-04-21)
- Updated dependencies []:
    - @posthog/types@1.369.4

---

#### [`@posthog/types@1.369.4`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.369.4)

## 1.369.4

---

#### [`posthog-js@1.369.5`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.369.5)

## 1.369.5

### Patch Changes

- Updated dependencies [[`1a0b58d`](https://github.com/PostHog/posthog-js/commit/1a0b58d1d07c61662169d3bc56eed8cfd8855d65)]:
    - @posthog/core@1.25.3
    - @posthog/types@1.369.5

---

#### [`@posthog/types@1.369.5`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.369.5)

## 1.369.5

---

#### [`posthog-js@1.370.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.370.0)

## 1.370.0

### Minor Changes

- [#3389](https://github.com/PostHog/posthog-js/pull/3389) [`922a1c1`](https://github.com/PostHog/posthog-js/commit/922a1c1838a5ed2ad37f59dade5fc3cc81bb4246) Thanks [@hpouillot](https://github.com/hpouillot)! - Add exception steps to error tracking (aka breadcrumbs)
  (2026-04-22)

### Patch Changes

- Updated dependencies [[`922a1c1`](https://github.com/PostHog/posthog-js/commit/922a1c1838a5ed2ad37f59dade5fc3cc81bb4246)]:
    - @posthog/types@1.370.0
    - @posthog/core@1.26.0

---

#### [`@posthog/types@1.370.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.370.0)

## 1.370.0

### Minor Changes

- [#3389](https://github.com/PostHog/posthog-js/pull/3389) [`922a1c1`](https://github.com/PostHog/posthog-js/commit/922a1c1838a5ed2ad37f59dade5fc3cc81bb4246) Thanks [@hpouillot](https://github.com/hpouillot)! - Add exception steps to error tracking (aka breadcrumbs)
  (2026-04-22)

---

#### [`posthog-js@1.370.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.370.1)

## 1.370.1

### Patch Changes

- [#3442](https://github.com/PostHog/posthog-js/pull/3442) [`6f19ce8`](https://github.com/PostHog/posthog-js/commit/6f19ce8fed80f81e75552c5725b648e5f2e53634) Thanks [@marandaneto](https://github.com/marandaneto)! - fix(surveys): guard survey seen localStorage access
  (2026-04-22)
- Updated dependencies []:
    - @posthog/types@1.370.1

---

#### [`@posthog/types@1.370.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.370.1)

## 1.370.1

---

#### [`posthog-js@1.371.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.371.0)

## 1.371.0

### Patch Changes

- [#3432](https://github.com/PostHog/posthog-js/pull/3432) [`1a8b727`](https://github.com/PostHog/posthog-js/commit/1a8b7277c50a42bbb3f736afd530ff1c3389a7de) Thanks [@richardsolomou](https://github.com/richardsolomou)! - refactor: rename `__add_tracing_headers` to `addTracingHeaders`. The `__` prefix signalled an internal/experimental option, but the config is a public API (documented for linking LLM traces to session replays). `__add_tracing_headers` continues to work as a deprecated alias on the browser SDK.

    Also exposes `patchFetchForTracingHeaders` from `@posthog/core` so non-browser SDKs can reuse the implementation. (2026-04-23)

- Updated dependencies [[`1a8b727`](https://github.com/PostHog/posthog-js/commit/1a8b7277c50a42bbb3f736afd530ff1c3389a7de)]:
    - @posthog/core@1.27.0
    - @posthog/types@1.371.0

---

#### [`@posthog/types@1.371.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.371.0)

## 1.371.0

### Minor Changes

- [#3432](https://github.com/PostHog/posthog-js/pull/3432) [`1a8b727`](https://github.com/PostHog/posthog-js/commit/1a8b7277c50a42bbb3f736afd530ff1c3389a7de) Thanks [@richardsolomou](https://github.com/richardsolomou)! - refactor: rename `__add_tracing_headers` to `addTracingHeaders`. The `__` prefix signalled an internal/experimental option, but the config is a public API (documented for linking LLM traces to session replays). `__add_tracing_headers` continues to work as a deprecated alias on the browser SDK.

    Also exposes `patchFetchForTracingHeaders` from `@posthog/core` so non-browser SDKs can reuse the implementation. (2026-04-23)

---

#### [`posthog-js@1.371.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.371.1)

## 1.371.1

### Patch Changes

- [#3425](https://github.com/PostHog/posthog-js/pull/3425) [`2da17e8`](https://github.com/PostHog/posthog-js/commit/2da17e8c94b2705cb5852a9fe993925bf1e24b55) Thanks [@marandaneto](https://github.com/marandaneto)! - Classify SDK-owned persistence keys with an explicit event exposure policy so new internal persistence state must be intentionally marked as event-visible, hidden, or derived.
  (2026-04-23)
- Updated dependencies []:
    - @posthog/types@1.371.1

---

#### [`@posthog/types@1.371.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.371.1)

## 1.371.1

---

#### [`posthog-js@1.371.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.371.2)

## 1.371.2

### Patch Changes

- [#3453](https://github.com/PostHog/posthog-js/pull/3453) [`96f19b7`](https://github.com/PostHog/posthog-js/commit/96f19b79d563937ed8f98e12796eee541a2dae7f) Thanks [@turnipdabeets](https://github.com/turnipdabeets)! - Lift OTLP log serialization helpers from posthog-js into @posthog/core so the
  upcoming React Native logs feature consumes the same builders. Browser gains
  two fixes as a side effect: NaN and ±Infinity attribute values no longer get
  silently dropped during JSON encoding, and the scope.version OTLP field is
  now populated with the SDK version (changes the server's instrumentation_scope
  column from "posthog-js@" to "posthog-js@<semver>"). (2026-04-23)
- Updated dependencies [[`96f19b7`](https://github.com/PostHog/posthog-js/commit/96f19b79d563937ed8f98e12796eee541a2dae7f)]:
    - @posthog/types@1.371.2
    - @posthog/core@1.27.1

---

#### [`@posthog/types@1.371.2`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.371.2)

## 1.371.2

### Patch Changes

- [#3453](https://github.com/PostHog/posthog-js/pull/3453) [`96f19b7`](https://github.com/PostHog/posthog-js/commit/96f19b79d563937ed8f98e12796eee541a2dae7f) Thanks [@turnipdabeets](https://github.com/turnipdabeets)! - Lift OTLP log serialization helpers from posthog-js into @posthog/core so the
  upcoming React Native logs feature consumes the same builders. Browser gains
  two fixes as a side effect: NaN and ±Infinity attribute values no longer get
  silently dropped during JSON encoding, and the scope.version OTLP field is
  now populated with the SDK version (changes the server's instrumentation_scope
  column from "posthog-js@" to "posthog-js@<semver>"). (2026-04-23)

---

#### [`posthog-js@1.371.3`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.371.3)

## 1.371.3

### Patch Changes

- [#3445](https://github.com/PostHog/posthog-js/pull/3445) [`61cf83e`](https://github.com/PostHog/posthog-js/commit/61cf83efbd0dd846ace9281b001daa0d633fcd8c) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - Fix session recording in the full no-external browser bundles
  (2026-04-24)
- Updated dependencies [[`daf028d`](https://github.com/PostHog/posthog-js/commit/daf028d553f756b9f58c01b848ad2d431239458b)]:
    - @posthog/core@1.27.2
    - @posthog/types@1.371.3

---

#### [`@posthog/types@1.371.3`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.371.3)

## 1.371.3

---

#### [`posthog-js@1.371.4`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.371.4)

## 1.371.4

### Patch Changes

- [#3469](https://github.com/PostHog/posthog-js/pull/3469) [`3c4fc1e`](https://github.com/PostHog/posthog-js/commit/3c4fc1e70f3f2394fbdd141efda44bdbddbb9062) Thanks [@fasyy612](https://github.com/fasyy612)! - bump rrweb to 0.0.60
  (2026-04-24)
- Updated dependencies []:
    - @posthog/types@1.371.4
    - @posthog/core@1.27.3

---

#### [`@posthog/types@1.371.4`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.371.4)

## 1.371.4

---

#### [`posthog-js@1.372.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.372.0)

## 1.372.0

### Minor Changes

- [#3470](https://github.com/PostHog/posthog-js/pull/3470) [`eaa1322`](https://github.com/PostHog/posthog-js/commit/eaa1322bcbf6606bb188f84ac64246a8cfb22256) Thanks [@veryayskiy](https://github.com/veryayskiy)! - You cannot write to a resolve ticket. Start a new one.
  (2026-04-24)

### Patch Changes

- Updated dependencies []:
    - @posthog/types@1.372.0
    - @posthog/core@1.27.4

---

#### [`@posthog/types@1.372.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.372.0)

## 1.372.0

---

#### [`posthog-js@1.372.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.372.1)

## 1.372.1

### Patch Changes

- [#3464](https://github.com/PostHog/posthog-js/pull/3464) [`70508df`](https://github.com/PostHog/posthog-js/commit/70508dfd7dd1201dd9c61c126a3c27ad39311c6a) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - Avoid using `Blob.stream()` for native async gzip compression to prevent Safari `NotReadableError` stream failures.
  (2026-04-24)
- Updated dependencies [[`70508df`](https://github.com/PostHog/posthog-js/commit/70508dfd7dd1201dd9c61c126a3c27ad39311c6a)]:
    - @posthog/core@1.27.5
    - @posthog/types@1.372.1

---

#### [`@posthog/types@1.372.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.372.1)

## 1.372.1

---

#### [`posthog-js@1.372.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.372.2)

## 1.372.2

### Patch Changes

- [#3484](https://github.com/PostHog/posthog-js/pull/3484) [`cba2570`](https://github.com/PostHog/posthog-js/commit/cba25700dca2e8d8e138ea6034bd42dc9d002596) Thanks [@veryayskiy](https://github.com/veryayskiy)! - Fix autofocus
  (2026-04-27)
- Updated dependencies []:
    - @posthog/types@1.372.2
    - @posthog/core@1.27.6

---

#### [`@posthog/types@1.372.2`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.372.2)

## 1.372.2

---

#### [`posthog-js@1.372.3`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.372.3)

## 1.372.3

### Patch Changes

- [#3488](https://github.com/PostHog/posthog-js/pull/3488) [`5b8efc3`](https://github.com/PostHog/posthog-js/commit/5b8efc35d9acf77db2d6979ffa4b655b5f279721) Thanks [@lucasheriques](https://github.com/lucasheriques)! - Add browser survey translation rendering and language tracking.
  (2026-04-27)
- Updated dependencies []:
    - @posthog/types@1.372.3
    - @posthog/core@1.27.7

---

#### [`@posthog/types@1.372.3`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.372.3)

## 1.372.3

---

#### [`posthog-js@1.372.4`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.372.4)

## 1.372.4

### Patch Changes

- [#3495](https://github.com/PostHog/posthog-js/pull/3495) [`5a6b2a5`](https://github.com/PostHog/posthog-js/commit/5a6b2a55c015345909f93f744ebddd618e1fc85d) Thanks [@posthog](https://github.com/apps/posthog)! - Fix copy autocapture when copying or cutting text from Shadow DOM or document fragment contexts.
  (2026-04-29)
- Updated dependencies []:
    - @posthog/types@1.372.4
    - @posthog/core@1.27.8

---

#### [`@posthog/types@1.372.4`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.372.4)

## 1.372.4

---

#### [`posthog-js@1.372.5`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.372.5)

## 1.372.5

### Patch Changes

- [#3448](https://github.com/PostHog/posthog-js/pull/3448) [`c726aae`](https://github.com/PostHog/posthog-js/commit/c726aaea62483509469317870e6c3a3bedee3f18) Thanks [@posthog](https://github.com/apps/posthog)! - fix(exceptions): avoid cross-origin property access when calling the previous `window.onunhandledrejection` handler
  (2026-04-29)
- Updated dependencies []:
    - @posthog/types@1.372.5
    - @posthog/core@1.27.9

---

#### [`@posthog/types@1.372.5`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.372.5)

## 1.372.5

---

#### [`posthog-js@1.372.6`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.372.6)

## 1.372.6

### Patch Changes

- [#3492](https://github.com/PostHog/posthog-js/pull/3492) [`cf56753`](https://github.com/PostHog/posthog-js/commit/cf56753d775225df2751dee2de7987d4a47fef8c) Thanks [@lucasheriques](https://github.com/lucasheriques)! - Add translated survey rendering support in React Native and share survey translation logic through `@posthog/core`.
  (2026-05-01)
- Updated dependencies [[`cf56753`](https://github.com/PostHog/posthog-js/commit/cf56753d775225df2751dee2de7987d4a47fef8c), [`04db756`](https://github.com/PostHog/posthog-js/commit/04db75663208251d1b09c80b09e5d00188e897fd)]:
    - @posthog/core@1.28.0
    - @posthog/types@1.372.6

---

#### [`@posthog/types@1.372.6`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.372.6)

## 1.372.6

---

#### [`posthog-js@1.372.7`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.372.7)

## 1.372.7

### Patch Changes

- Updated dependencies [[`8aee3d5`](https://github.com/PostHog/posthog-js/commit/8aee3d55f8e2bf7a14a534c940327d8e08ba64f6)]:
    - @posthog/core@1.28.1
    - @posthog/types@1.372.7

---

#### [`@posthog/types@1.372.7`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.372.7)

## 1.372.7

---

#### [`posthog-js@1.372.8`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.372.8)

## 1.372.8

### Patch Changes

- [#3515](https://github.com/PostHog/posthog-js/pull/3515) [`255b273`](https://github.com/PostHog/posthog-js/commit/255b27380658b450d1427d4a478e4d7a4bf773f1) Thanks [@marandaneto](https://github.com/marandaneto)! - Gate survey translation logs behind SDK debug logging to avoid production console spam.
  (2026-05-04)
- Updated dependencies [[`220cd61`](https://github.com/PostHog/posthog-js/commit/220cd61e332ca4982c7bc3b6f740d797ef9e4e7f), [`255b273`](https://github.com/PostHog/posthog-js/commit/255b27380658b450d1427d4a478e4d7a4bf773f1)]:
    - @posthog/core@1.28.2
    - @posthog/types@1.372.8

---

#### [`@posthog/types@1.372.8`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.372.8)

## 1.372.8

---

#### [`posthog-js@1.372.9`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.372.9)

## 1.372.9

### Patch Changes

- [#3537](https://github.com/PostHog/posthog-js/pull/3537) [`026e09d`](https://github.com/PostHog/posthog-js/commit/026e09d3d540ce39c06e88cd39db6c08403e855d) Thanks [@TueHaulund](https://github.com/TueHaulund)! - Pull in the canvas-manager fix from `@posthog/rrweb` 0.0.61: skip canvas
  snapshots while the WebGL context is lost so transparent bitmaps don't
  poison the worker's fingerprint dedup map and silently kill canvas
  recording for the rest of the session. Also wraps `getCanvas()` in
  try/catch so DOM/shadow-root traversal errors can't cancel the rAF
  loop. See PR #3527 for context. (2026-05-05)
- Updated dependencies []:
    - @posthog/types@1.372.9
    - @posthog/core@1.28.3

---

#### [`@posthog/types@1.372.9`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.372.9)

## 1.372.9

---

#### [`posthog-js@1.372.10`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.372.10)

## 1.372.10

### Patch Changes

- [#3544](https://github.com/PostHog/posthog-js/pull/3544) [`d120042`](https://github.com/PostHog/posthog-js/commit/d12004237985bc552423e31e75bb0fa42d0921ca) Thanks [@ksvat](https://github.com/ksvat)! - fix: stop session recording before destroying sessionManager in `opt_out_capturing()` with `cookieless_mode: "on_reject"`. Previously, queued/throttled rrweb events (e.g. mousemove) could fire after the sessionManager was set to `undefined` and throw `[SessionRecording] must be started with a valid sessionManager`. Also adds a defensive early-return in `onRRwebEmit` so any remaining late events bail out instead of throwing.
  (2026-05-07)

- [#3542](https://github.com/PostHog/posthog-js/pull/3542) [`94a5ba0`](https://github.com/PostHog/posthog-js/commit/94a5ba0cf6d3a0f943517a126a59f52baa77f2fe) Thanks [@TueHaulund](https://github.com/TueHaulund)! - Preserve `<style>` textContent when the browser's CSSOM serialization would
  emit empty longhands from `var()` inside a shorthand. When a stylesheet has
  e.g. `padding: var(--p); padding-bottom: var(--pb);`, browsers store the
  shorthand's longhands with empty token lists per the CSS Custom Properties
  spec, and `CSSStyleRule.cssText` re-emits them as `padding-top: ;
padding-right: ; padding-left: ;`. The previous behavior replaced the
  `<style>` text with that corrupted output, silently dropping layout rules
  on replay. We now detect the empty-longhand pattern and keep the original
  textContent in that case. Affects users of any CSS-in-JS framework that
  combines `var()` with shorthands (Chakra UI v3, Panda CSS, Emotion, etc.).
  Same class of bug as rrweb-io/rrweb#1667. (2026-05-07)
- Updated dependencies []:
    - @posthog/types@1.372.10
    - @posthog/core@1.28.4

---

#### [`@posthog/types@1.372.10`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.372.10)

## 1.372.10

---

#### [`posthog-js@1.373.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.373.0)

## 1.373.0

### Minor Changes

- [#3547](https://github.com/PostHog/posthog-js/pull/3547) [`4c0c7d9`](https://github.com/PostHog/posthog-js/commit/4c0c7d9f48e6f4f5301f8208285191f62dc8407a) Thanks [@williamchong](https://github.com/williamchong)! - `capture()` now accepts an optional `uuid` on `CaptureOptions`.
  (2026-05-11)

### Patch Changes

- [#3561](https://github.com/PostHog/posthog-js/pull/3561) [`3511848`](https://github.com/PostHog/posthog-js/commit/3511848fd03bd77b117dccc6f06237a06d38d618) Thanks [@marandaneto](https://github.com/marandaneto)! - Handle invalid persisted session replay config JSON gracefully

- [#3559](https://github.com/PostHog/posthog-js/pull/3559) [`0a835fa`](https://github.com/PostHog/posthog-js/commit/0a835fa1d5db988d508aa023240ab5b4b50f0969) Thanks [@marandaneto](https://github.com/marandaneto)! - Skip remote config background refreshes when no document is available.
- Updated dependencies [[`4c0c7d9`](https://github.com/PostHog/posthog-js/commit/4c0c7d9f48e6f4f5301f8208285191f62dc8407a), [`0a835fa`](https://github.com/PostHog/posthog-js/commit/0a835fa1d5db988d508aa023240ab5b4b50f0969)]:
    - @posthog/types@1.373.0
    - @posthog/core@1.28.5

---

#### [`@posthog/types@1.373.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.373.0)

## 1.373.0

### Minor Changes

- [#3547](https://github.com/PostHog/posthog-js/pull/3547) [`4c0c7d9`](https://github.com/PostHog/posthog-js/commit/4c0c7d9f48e6f4f5301f8208285191f62dc8407a) Thanks [@williamchong](https://github.com/williamchong)! - `capture()` now accepts an optional `uuid` on `CaptureOptions`.
  (2026-05-11)

### Patch Changes

- [#3559](https://github.com/PostHog/posthog-js/pull/3559) [`0a835fa`](https://github.com/PostHog/posthog-js/commit/0a835fa1d5db988d508aa023240ab5b4b50f0969) Thanks [@marandaneto](https://github.com/marandaneto)! - Skip remote config background refreshes when no document is available.

---

#### [`posthog-js@1.373.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.373.1)

## 1.373.1

### Patch Changes

- [#3566](https://github.com/PostHog/posthog-js/pull/3566) [`7d027bc`](https://github.com/PostHog/posthog-js/commit/7d027bcfef3f0ffa47bdb31cd41f07784c2f2e7c) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - Prevent browser log capture from throwing when console arguments contain unreadable properties.
  (2026-05-11)
- Updated dependencies []:
    - @posthog/types@1.373.1
    - @posthog/core@1.28.6

---

#### [`@posthog/types@1.373.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.373.1)

## 1.373.1

---

#### [`posthog-js@1.373.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.373.2)

## 1.373.2

### Patch Changes

- [#3568](https://github.com/PostHog/posthog-js/pull/3568) [`223d925`](https://github.com/PostHog/posthog-js/commit/223d9255e3dfb02af099b7529292cb56854daa77) Thanks [@marandaneto](https://github.com/marandaneto)! - Validate native gzip output before sending requests and fall back when CompressionStream returns malformed data.
  (2026-05-11)
- Updated dependencies [[`223d925`](https://github.com/PostHog/posthog-js/commit/223d9255e3dfb02af099b7529292cb56854daa77)]:
    - @posthog/core@1.28.7
    - @posthog/types@1.373.2

---

#### [`@posthog/types@1.373.2`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.373.2)

## 1.373.2

---

#### [`posthog-js@1.373.3`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.373.3)

## 1.373.3

### Patch Changes

- Updated dependencies [[`ad60818`](https://github.com/PostHog/posthog-js/commit/ad60818222252f1b65bb8778b12862c287168422)]:
    - @posthog/core@1.29.0
    - @posthog/types@1.373.3

---

#### [`@posthog/types@1.373.3`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.373.3)

## 1.373.3

---

#### [`posthog-js@1.373.4`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.373.4)

## 1.373.4

### Patch Changes

- [#3602](https://github.com/PostHog/posthog-js/pull/3602) [`4b895bf`](https://github.com/PostHog/posthog-js/commit/4b895bf0151f24c0b72e8ce4cae47906795b29b8) Thanks [@marandaneto](https://github.com/marandaneto)! - Validate gzip request bodies at the browser send boundary and fall back to JSON if the outgoing body is not gzip data.
  (2026-05-12)
- Updated dependencies [[`4b895bf`](https://github.com/PostHog/posthog-js/commit/4b895bf0151f24c0b72e8ce4cae47906795b29b8)]:
    - @posthog/core@1.29.1
    - @posthog/types@1.373.4

---

#### [`@posthog/types@1.373.4`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.373.4)

## 1.373.4

---

#### [`posthog-js@1.373.5`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.373.5)

## 1.373.5

### Patch Changes

- [#3613](https://github.com/PostHog/posthog-js/pull/3613) [`221973e`](https://github.com/PostHog/posthog-js/commit/221973e4a2a50196ffb5c45c468f3de812ed82cf) Thanks [@lucasheriques](https://github.com/lucasheriques)! - Surveys: submit open text questions with Cmd/Ctrl+Enter. The textarea still inserts a newline on plain Enter (native behaviour), matching the convention used by Slack, GitHub, Discord, and ChatGPT for multi-line inputs. Single-line "Other:" inputs continue to submit on plain Enter as before.
  (2026-05-15)
- Updated dependencies []:
    - @posthog/types@1.373.5
    - @posthog/core@1.29.2

---

#### [`@posthog/types@1.373.5`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.373.5)

## 1.373.5

---

#### [`posthog-js@1.374.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.374.0)

## 1.374.0

### Minor Changes

- [#3620](https://github.com/PostHog/posthog-js/pull/3620) [`594ea11`](https://github.com/PostHog/posthog-js/commit/594ea1146045d49080f6dfd951b037c13278e975) Thanks [@pauldambra](https://github.com/pauldambra)! - Dead clicks: add a `.ph-no-deadclick` CSS class (and `capture_dead_clicks.css_selector_ignorelist` config option) to exclude specific elements from dead-click detection without affecting autocapture, session replay, or heatmaps. Mirrors the existing `.ph-no-rageclick` pattern.
  (2026-05-18)

### Patch Changes

- [#3621](https://github.com/PostHog/posthog-js/pull/3621) [`3c0a09f`](https://github.com/PostHog/posthog-js/commit/3c0a09f05ab768b94b5518a3109e44a5c9f33c70) Thanks [@pauldambra](https://github.com/pauldambra)! - Dead clicks: a click on an `<a>` (or any element inside an `<a>`, including across shadow DOM) is no longer flagged as a dead click — the browser navigates / downloads / opens a new window and we can't observe that. Reuses autocapture's existing DOM walker for the ancestor walk. Direct clicks on `<button>`, `<input>`, `<select>`, `<textarea>`, `<label>`, and `<form>` (previously all skipped) are now eligible for dead-click detection: if their JS handler ran, the existing mutation / scroll / selection observers see the effect; if it didn't, dead-click correctly surfaces the bug. A broken `<button>` with no handler, or an `<svg>` icon inside one, will now flag — which is exactly the dead-click case we want to catch.
- Updated dependencies [[`594ea11`](https://github.com/PostHog/posthog-js/commit/594ea1146045d49080f6dfd951b037c13278e975)]:
    - @posthog/types@1.374.0
    - @posthog/core@1.29.3

---

#### [`@posthog/types@1.374.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.374.0)

## 1.374.0

### Minor Changes

- [#3620](https://github.com/PostHog/posthog-js/pull/3620) [`594ea11`](https://github.com/PostHog/posthog-js/commit/594ea1146045d49080f6dfd951b037c13278e975) Thanks [@pauldambra](https://github.com/pauldambra)! - Dead clicks: add a `.ph-no-deadclick` CSS class (and `capture_dead_clicks.css_selector_ignorelist` config option) to exclude specific elements from dead-click detection without affecting autocapture, session replay, or heatmaps. Mirrors the existing `.ph-no-rageclick` pattern.
  (2026-05-18)

---

#### [`posthog-js@1.374.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.374.1)

## 1.374.1

### Patch Changes

- [#3627](https://github.com/PostHog/posthog-js/pull/3627) [`07a0f5f`](https://github.com/PostHog/posthog-js/commit/07a0f5f7a25f9867047dd6c633b881f45caef72c) Thanks [@marandaneto](https://github.com/marandaneto)! - Respect transport overrides passed to posthog.capture.
  (2026-05-18)
- Updated dependencies []:
    - @posthog/types@1.374.1
    - @posthog/core@1.29.4

---

#### [`@posthog/types@1.374.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.374.1)

## 1.374.1

---

#### [`posthog-js@1.374.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.374.2)

## 1.374.2

### Patch Changes

- [#3550](https://github.com/PostHog/posthog-js/pull/3550) [`df91995`](https://github.com/PostHog/posthog-js/commit/df919950f298741980ed302828736cbf6785b1eb) Thanks [@TueHaulund](https://github.com/TueHaulund)! - Preserve session-recording remote config across `posthog.reset()`.

    `posthog.reset()` was clearing the entire persistence store, which wiped
    `$session_recording_remote_config` along with user state. On the next session
    rotation triggered by the reset, `start('session_id_changed')` would early-return
    because the remote config was missing — leaving rrweb torn down and the new
    session opening with no Meta + FullSnapshot until the next periodic 5-minute
    checkout.

    This affected any flow where an app calls `posthog.reset()` mid-session
    (e.g. on sign-out / sign-in) and was particularly visible on Flutter Web
    recordings that depend on a fresh FullSnapshot to anchor the CanvasKit DOM. (2026-05-18)

- Updated dependencies []:
    - @posthog/types@1.374.2
    - @posthog/core@1.29.5

---

#### [`@posthog/types@1.374.2`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.374.2)

## 1.374.2

---

#### [`posthog-js@1.374.3`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.374.3)

## 1.374.3

### Patch Changes

- [#3607](https://github.com/PostHog/posthog-js/pull/3607) [`557b893`](https://github.com/PostHog/posthog-js/commit/557b8934aa0b990184e0376fb1fc28433ad336c6) Thanks [@eli-r-ph](https://github.com/eli-r-ph)! - Enable $web_vitals reporting when cookieless mode is enabled
  (2026-05-20)
- Updated dependencies [[`557b893`](https://github.com/PostHog/posthog-js/commit/557b8934aa0b990184e0376fb1fc28433ad336c6), [`a880dbc`](https://github.com/PostHog/posthog-js/commit/a880dbcbbfd01bbef939c627f3b541744e3c3587)]:
    - @posthog/types@1.374.3
    - @posthog/core@1.29.6

---

#### [`@posthog/types@1.374.3`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.374.3)

## 1.374.3

### Patch Changes

- [#3607](https://github.com/PostHog/posthog-js/pull/3607) [`557b893`](https://github.com/PostHog/posthog-js/commit/557b8934aa0b990184e0376fb1fc28433ad336c6) Thanks [@eli-r-ph](https://github.com/eli-r-ph)! - Enable $web_vitals reporting when cookieless mode is enabled
  (2026-05-20)

---

#### [`posthog-js@1.374.4`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.374.4)

## 1.374.4

### Patch Changes

- [#3638](https://github.com/PostHog/posthog-js/pull/3638) [`87e2145`](https://github.com/PostHog/posthog-js/commit/87e2145b5d09ed8a24df1fc337dad5c3c90c1b8a) Thanks [@marandaneto](https://github.com/marandaneto)! - Apply tracing headers to matching XMLHttpRequest requests
  (2026-05-21)

- [#3646](https://github.com/PostHog/posthog-js/pull/3646) [`4f87827`](https://github.com/PostHog/posthog-js/commit/4f87827dda9c102a6deded986f2afd9fdddfb2e5) Thanks [@marandaneto](https://github.com/marandaneto)! - Avoid throwing or initializing PostHogProvider when no API key or client is provided

- [#3645](https://github.com/PostHog/posthog-js/pull/3645) [`280832b`](https://github.com/PostHog/posthog-js/commit/280832b50b4c058e010436c4aab861cb143577c1) Thanks [@TueHaulund](https://github.com/TueHaulund)! - Capture `<link rel="stylesheet">` URLs from `link.sheet.href` and try `link.sheet` directly for inlining, so recordings survive SPA `history.pushState` navigations between routes of different path depths (where `link.href` re-resolves against a new baseURI but `link.sheet.href` preserves the URL the browser actually fetched).

    Ships the fix landed in #3635, which only bumped the internal `@posthog/rrweb-snapshot` package — that package is bundled into `posthog-js` at build time but is not published to npm on its own, so a `posthog-js` bump is needed to actually deliver the change. (2026-05-21)

- Updated dependencies []:
    - @posthog/types@1.374.4
    - @posthog/core@1.29.7

---

#### [`@posthog/types@1.374.4`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.374.4)

## 1.374.4

---

#### [`posthog-js@1.375.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.375.0)

## 1.375.0

### Minor Changes

- [#3641](https://github.com/PostHog/posthog-js/pull/3641) [`2e1d5f4`](https://github.com/PostHog/posthog-js/commit/2e1d5f4081c98a04e6a16f57e42491911453994d) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - Add `flag_keys` config to restrict browser feature flag remote evaluation to specific flag keys.
  (2026-05-21)

### Patch Changes

- Updated dependencies [[`2e1d5f4`](https://github.com/PostHog/posthog-js/commit/2e1d5f4081c98a04e6a16f57e42491911453994d)]:
    - @posthog/types@1.375.0
    - @posthog/core@1.29.8

---

#### [`@posthog/types@1.375.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.375.0)

## 1.375.0

### Minor Changes

- [#3641](https://github.com/PostHog/posthog-js/pull/3641) [`2e1d5f4`](https://github.com/PostHog/posthog-js/commit/2e1d5f4081c98a04e6a16f57e42491911453994d) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - Add `flag_keys` config to restrict browser feature flag remote evaluation to specific flag keys.
  (2026-05-21)

---

#### [`posthog-js@1.376.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.376.0)

## 1.376.0

### Minor Changes

- [#3655](https://github.com/PostHog/posthog-js/pull/3655) [`6e8d349`](https://github.com/PostHog/posthog-js/commit/6e8d3495d0a29076aeea5220e19e646aeb7f063f) Thanks [@arnaudhillen](https://github.com/arnaudhillen)! - Expose the in-repo `@posthog/rrweb`, `@posthog/rrweb-types`, and `@posthog/rrweb-plugin-console-record` packages as subpath entry points on `posthog-js`. Consumers can now `import { Replayer } from 'posthog-js/rrweb'`, `import type { eventWithTime } from 'posthog-js/rrweb-types'`, and `import { LogLevel } from 'posthog-js/rrweb-plugin-console-record'` instead of installing the underlying rrweb packages directly. The rrweb worker sourcemap (`image-bitmap-data-url-worker-*.js.map`) is also shipped from `posthog-js/dist/` so downstream bundlers no longer need to reach into `node_modules/@posthog/rrweb`.
  (2026-05-22)

### Patch Changes

- [#3639](https://github.com/PostHog/posthog-js/pull/3639) [`c806cca`](https://github.com/PostHog/posthog-js/commit/c806ccafdcc39b38e9554f8a17a8c2fbd3361dda) Thanks [@marandaneto](https://github.com/marandaneto)! - Use native async gzip compression for session recording events when CompressionStream is available.
- Updated dependencies [[`c806cca`](https://github.com/PostHog/posthog-js/commit/c806ccafdcc39b38e9554f8a17a8c2fbd3361dda)]:
    - @posthog/core@1.29.9
    - @posthog/types@1.376.0

---

#### [`@posthog/types@1.376.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.376.0)

## 1.376.0

---

#### [`posthog-js@1.376.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.376.1)

## 1.376.1

### Patch Changes

- Updated dependencies [[`5568f12`](https://github.com/PostHog/posthog-js/commit/5568f12f46b4ebb7539f261edddda2f695ba03a2)]:
    - @posthog/core@1.29.10
    - @posthog/types@1.376.1

---

#### [`@posthog/types@1.376.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.376.1)

## 1.376.1

---

#### [`posthog-js@1.376.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.376.2)

## 1.376.2

### Patch Changes

- [#3667](https://github.com/PostHog/posthog-js/pull/3667) [`cafa9cc`](https://github.com/PostHog/posthog-js/commit/cafa9cc786a07613677ec16f2fc9f0c4e833a12c) Thanks [@pauldambra](https://github.com/pauldambra)! - fix(replay): stop polling preload-as-style `<link>` elements forever. Session recorder treated `<link rel="preload" as="style" href="*.css">` as if it were a stylesheet and waited for `link.sheet` to populate. Per spec preload links never instantiate a `CSSStyleSheet`, so the wait timed out, re-serialized the link, scheduled another wait, and leaked a `load` listener on every cycle — multiplying further on every real `load` event. Pages with Next.js-style CSS preloads accumulated thousands of active polling chains, saturating the main thread and freezing the tab on refocus
  (2026-05-26)
- Updated dependencies []:
    - @posthog/types@1.376.2
    - @posthog/core@1.29.11

---

#### [`@posthog/types@1.376.2`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.376.2)

## 1.376.2

---

#### [`posthog-js@1.376.3`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.376.3)

## 1.376.3

### Patch Changes

- [#3649](https://github.com/PostHog/posthog-js/pull/3649) [`9cac1f6`](https://github.com/PostHog/posthog-js/commit/9cac1f650ed994a067bbffc5ec16b6d4dc65254f) Thanks [@marandaneto](https://github.com/marandaneto)! - Improve console log serialization performance for large objects.
  (2026-05-27)
- Updated dependencies []:
    - @posthog/types@1.376.3
    - @posthog/core@1.29.12

---

#### [`@posthog/types@1.376.3`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.376.3)

## 1.376.3

---

#### [`posthog-js@1.376.4`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.376.4)

## 1.376.4

### Patch Changes

- [#3685](https://github.com/PostHog/posthog-js/pull/3685) [`f59f35a`](https://github.com/PostHog/posthog-js/commit/f59f35ac5a6a0aa98be5f3ea3b88370df8d398aa) Thanks [@ioannisj](https://github.com/ioannisj)! - fix(cookieless): enable request queue when opting out in `on_reject` mode. When using `cookieless_mode: "on_reject"`, calling `opt_out_capturing()` correctly switched the SDK into cookieless capturing but never enabled the `RequestQueue` — so batched events were enqueued but never flushed over the network. At init time the queue was not started because consent was `PENDING` and `is_capturing()` returned `false`; `opt_out_capturing()` is the first moment capturing becomes active but was missing the `_start_queue_if_opted_in()` call that `opt_in_capturing()` already had.
  (2026-05-28)

- [#3692](https://github.com/PostHog/posthog-js/pull/3692) [`f01cd93`](https://github.com/PostHog/posthog-js/commit/f01cd939e096820b84666a463a61775ef69ce4c4) Thanks [@ksvat](https://github.com/ksvat)! - fix(replay): take a fresh full snapshot after session ID rotates via `forcedIdleReset`. Previously, when the session manager's idle enforcement timer rotated the session id, the recorder tore down rrweb and set `_isIdle = 'unknown'` before the new session id was observed. Neither restart path then fired (the `_onSessionIdCallback` guard only restarted when `_isIdle === true`, and `_updateWindowAndSessionIds` could not run with rrweb stopped), so the new session received only incremental mutations until a later snapshot — leaving the player stuck on "Buffering". The restart guard now also fires when rrweb isn't running.

- [#3691](https://github.com/PostHog/posthog-js/pull/3691) [`cc71f3f`](https://github.com/PostHog/posthog-js/commit/cc71f3fa1f87838c28a68e593cd3f274f63db397) Thanks [@ksvat](https://github.com/ksvat)! - fix(replay): ship `ph-no-capture` absolute-position fix from #3678 to `posthog-js`. The original changeset only bumped `@posthog/rrweb` and `@posthog/rrweb-snapshot`; because `posthog-js` depends on `@posthog/rrweb` via `workspace:*`, the cascade did not bump `posthog-js`, so the rebuilt bundle containing the fix was not published. This changeset re-publishes `posthog-js` with the fix.

- [#3695](https://github.com/PostHog/posthog-js/pull/3695) [`e1ff722`](https://github.com/PostHog/posthog-js/commit/e1ff722bf0bd333ffdf5d077f8f60893aaf7ef5e) Thanks [@ksvat](https://github.com/ksvat)! - chore(replay): expose `$sdk_debug_rrweb_attached` and `$sdk_debug_rrweb_start_attempted` debug properties on captured events. Today the SDK already stamps several `$sdk_debug_*` properties (start reason, linked-flag trigger status, recording status) that report the SDK's _intent_ to record — they all flip to "active" as soon as the state machine evaluates the configured triggers. None of them observe whether rrweb actually attached and is producing events. The new booleans close that gap: `$sdk_debug_rrweb_start_attempted` is set when `_startRecorder()` is first entered, and `$sdk_debug_rrweb_attached` reflects whether `_stopRrweb` is currently a non-falsy stop handle (i.e. `rrwebRecord({...})` returned successfully and the recorder has not been torn down). No behavior change — this only adds two booleans to the existing `sdkDebugProperties` channel, used to diagnose cases where a session reports `trigger_activated` / `recording_status: active` but no `$snapshot` data is ever uploaded.
- Updated dependencies [[`7b84b75`](https://github.com/PostHog/posthog-js/commit/7b84b7599d076c9c3c86f923f7d56cf937ad9874)]:
    - @posthog/core@1.29.13
    - @posthog/types@1.376.4

---

#### [`@posthog/types@1.376.4`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.376.4)

## 1.376.4

---

#### [`posthog-js@1.376.5`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.376.5)

## 1.376.5

### Patch Changes

- [#3686](https://github.com/PostHog/posthog-js/pull/3686) [`66cbc59`](https://github.com/PostHog/posthog-js/commit/66cbc5987427d539999834a2db3f0110ba6bd8c5) Thanks [@pauldambra](https://github.com/pauldambra)! - fix(persistence): throttle session-activity timestamp writes to a 5s granularity. The in-memory value still moves at full resolution; only writes to localStorage/cookie are coalesced. Activity-timestamp-only updates within the granularity window are skipped, dropping localStorage write pressure and cross-tab `storage` event broadcasts on pages that capture many events per second. The pending in-memory value is flushed on `destroy` and `beforeunload` so a tab close inside the window does not leave the persisted value up to 5s stale for sibling tabs. The flush re-reads storage first and bails out if a sibling tab has rotated the session, so the flush cannot clobber the new session with the old id/start.
  (2026-05-31)
- Updated dependencies [[`d9ad199`](https://github.com/PostHog/posthog-js/commit/d9ad1993d320ffc899dd57ce2f1cf1787e9c6635)]:
    - @posthog/core@1.29.14
    - @posthog/types@1.376.5

---

#### [`@posthog/types@1.376.5`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.376.5)

## 1.376.5

---

#### [`posthog-js@1.376.6`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.376.6)

## 1.376.6

### Patch Changes

- [#3687](https://github.com/PostHog/posthog-js/pull/3687) [`663e250`](https://github.com/PostHog/posthog-js/commit/663e250b10df6bcadf42b7938fa3a77fb91f427b) Thanks [@pauldambra](https://github.com/pauldambra)! - fix(persistence): skip the storage write when the serialized props are unchanged. Callers spam `save()` after every property change, and many of those changes leave the serialized payload identical (e.g. resetting a value to its current value). Writing identical bytes to localStorage still fires a cross-tab `storage` event in every same-origin tab, where Chrome allocates the payload buffer in mojo IPC even though no listener reacts. Now `save()` compares the serialized payload against the last successful write and bails out when nothing changed.
  (2026-05-31)
- Updated dependencies []:
    - @posthog/types@1.376.6
    - @posthog/core@1.29.15

---

#### [`@posthog/types@1.376.6`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.376.6)

## 1.376.6

---

#### [`posthog-js@1.377.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.377.0)

## 1.377.0

### Minor Changes

- [#3708](https://github.com/PostHog/posthog-js/pull/3708) [`3d4a76f`](https://github.com/PostHog/posthog-js/commit/3d4a76f323ac789df91448fdb05d356dc91bb87f) Thanks [@pauldambra](https://github.com/pauldambra)! - Detect Brave (desktop, Android, iOS), Vivaldi, Yandex, Naver Whale, DuckDuckGo, Pale Moon, and Waterfox so users on these browsers no longer get bucketed as Chrome or Firefox.

    `detectBrowser` / `detectBrowserVersion` now accept an optional third argument, `BrowserDetectionHints`, with a `brave` flag (set when `navigator.brave` exists). The browser SDK populates this automatically to catch desktop / Android Brave, which is Chromium-based and carries no UA marker. Brave on iOS is picked up purely from the `Brave/` UA marker — WebKit doesn't ship `navigator.brave`. The original two-argument signature still works for non-DOM callers. (2026-06-01)

### Patch Changes

- [#3703](https://github.com/PostHog/posthog-js/pull/3703) [`f3cc6fa`](https://github.com/PostHog/posthog-js/commit/f3cc6fa8278547e8ea75c0b87d79cffa10158e45) Thanks [@marandaneto](https://github.com/marandaneto)! - Disable/no-op initialization paths instead of throwing or sending requests when PostHog project tokens are missing or blank.
  (2026-06-01)
- Updated dependencies [[`3d4a76f`](https://github.com/PostHog/posthog-js/commit/3d4a76f323ac789df91448fdb05d356dc91bb87f)]:
    - @posthog/core@1.30.0
    - @posthog/types@1.377.0

---

#### [`@posthog/types@1.377.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.377.0)

## 1.377.0

---

#### [`posthog-js@1.378.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.378.0)

## 1.378.0

### Minor Changes

- [#3688](https://github.com/PostHog/posthog-js/pull/3688) [`8181354`](https://github.com/PostHog/posthog-js/commit/8181354cae602f3f2b5e8c5b5bcd2e090e25edcc) Thanks [@pauldambra](https://github.com/pauldambra)! - feat(persistence): add `persistence_save_debounce_ms` config option to coalesce rapid storage saves into a single write. Setting a positive value debounces writes to localStorage/cookie by that window; the in-memory `props` object still updates synchronously so within-tab reads see the latest values immediately, and pending writes flush on `beforeunload` and `pagehide` so no state is lost on tab close. Cross-tab `storage` events are reduced proportionally to the debounce window. Defaults to `0` (no debouncing) for backwards compatibility. On pages that capture many events per second, `250` is a reasonable starting point. The new `2026-05-30` config default opts into `persistence_save_debounce_ms: 250` automatically.
  (2026-06-01)

### Patch Changes

- Updated dependencies [[`8181354`](https://github.com/PostHog/posthog-js/commit/8181354cae602f3f2b5e8c5b5bcd2e090e25edcc)]:
    - @posthog/types@1.378.0
    - @posthog/core@1.30.1

---

#### [`@posthog/types@1.378.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.378.0)

## 1.378.0

### Minor Changes

- [#3688](https://github.com/PostHog/posthog-js/pull/3688) [`8181354`](https://github.com/PostHog/posthog-js/commit/8181354cae602f3f2b5e8c5b5bcd2e090e25edcc) Thanks [@pauldambra](https://github.com/pauldambra)! - feat(persistence): add `persistence_save_debounce_ms` config option to coalesce rapid storage saves into a single write. Setting a positive value debounces writes to localStorage/cookie by that window; the in-memory `props` object still updates synchronously so within-tab reads see the latest values immediately, and pending writes flush on `beforeunload` and `pagehide` so no state is lost on tab close. Cross-tab `storage` events are reduced proportionally to the debounce window. Defaults to `0` (no debouncing) for backwards compatibility. On pages that capture many events per second, `250` is a reasonable starting point. The new `2026-05-30` config default opts into `persistence_save_debounce_ms: 250` automatically.
  (2026-06-01)

---

#### [`posthog-js@1.378.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.378.1)

## 1.378.1

### Patch Changes

- [#3706](https://github.com/PostHog/posthog-js/pull/3706) [`8fcf40d`](https://github.com/PostHog/posthog-js/commit/8fcf40d3798a107f446dd75b13b81088eac1ab2c) Thanks [@dustinbyrne](https://github.com/dustinbyrne)! - fix(browser): avoid exposing internally-created Request bodies to downstream fetch wrappers in Safari.
  (2026-06-01)
- Updated dependencies []:
    - @posthog/types@1.378.1
    - @posthog/core@1.30.2

---

#### [`@posthog/types@1.378.1`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.378.1)

## 1.378.1

---

#### [`posthog-js@1.379.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.379.0)

## 1.379.0

### Minor Changes

- [#3722](https://github.com/PostHog/posthog-js/pull/3722) [`c487070`](https://github.com/PostHog/posthog-js/commit/c48707071586135de3357bf94e4165605c93e321) Thanks [@marandaneto](https://github.com/marandaneto)! - Add `$sdk_dist_channel` event property for browser SDK `npm` and `cdn` distribution channels.
  (2026-06-02)

### Patch Changes

- Updated dependencies []:
    - @posthog/types@1.379.0
    - @posthog/core@1.30.3

---

#### [`@posthog/types@1.379.0`](https://github.com/PostHog/posthog-js/releases/tag/%40posthog/types%401.379.0)

## 1.379.0

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter posthog-js && pnpm install`
- Only `package.json` and `pnpm-lock.yaml` were modified.

🤖 Generated by the `update-deps` skill.
