### PR TITLE
chore(deps): bump zustand from 5.0.12 to 5.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
 		"react-dom": "18.3.1",
 		"react-i18next": "12.3.1",
 		"react-router-dom": "6.30.3",
-		"zustand": "5.0.12"
+		"zustand": "5.0.14"
 	},
 	"pnpm": {
 		"overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: 6.30.3
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zustand:
-        specifier: 5.0.12
-        version: 5.0.12(@types/react@18.3.28)(immer@10.2.0)(react@18.3.1)
+        specifier: 5.0.14
+        version: 5.0.14(@types/react@18.3.28)(immer@10.2.0)(react@18.3.1)
     devDependencies:
       '@babel/core':
         specifier: 7.29.0
@@ -7188,8 +7188,8 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
-  zustand@5.0.12:
-    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -14987,7 +14987,7 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
-  zustand@5.0.12(@types/react@18.3.28)(immer@10.2.0)(react@18.3.1):
+  zustand@5.0.14(@types/react@18.3.28)(immer@10.2.0)(react@18.3.1):
     optionalDependencies:
       '@types/react': 18.3.28
       immer: 10.2.0


### PR DESCRIPTION
## Bump `zustand` from `5.0.12` to `5.0.14`

Automated minor/patch update opened by the `update-deps` skill.

- **Old:** `5.0.12`
- **New:** `5.0.14`
- **npm:** https://www.npmjs.com/package/zustand/v/5.0.14

### Changelog


#### [`v5.0.13`](https://github.com/pmndrs/zustand/releases/tag/v5.0.13)

This release includes an improvement in the devtools middleware.

## What's Changed
* refactor(devtools): remove duplicate module augmentation by @mahmoodhamdi in https://github.com/pmndrs/zustand/pull/3443
* fix(devtools): support Firefox/Safari stack format in findCallerName by @SBolsec in https://github.com/pmndrs/zustand/pull/3469

## New Contributors
* @mahmoodhamdi made their first contribution in https://github.com/pmndrs/zustand/pull/3443
* @FelixEckl-vireq made their first contribution in https://github.com/pmndrs/zustand/pull/3466
* @KimHyeongRae0 made their first contribution in https://github.com/pmndrs/zustand/pull/3471
* @lstak made their first contribution in https://github.com/pmndrs/zustand/pull/3483
* @AlexRixten made their first contribution in https://github.com/pmndrs/zustand/pull/3474
* @SBolsec made their first contribution in https://github.com/pmndrs/zustand/pull/3469

**Full Changelog**: https://github.com/pmndrs/zustand/compare/v5.0.12...v5.0.13

---

#### [`v5.0.14`](https://github.com/pmndrs/zustand/releases/tag/v5.0.14)

This release fixes a type issue in devtools.

## What's Changed
* fix(devtools): improve type inference for Devtools initializer by @dbritto-dev in https://github.com/pmndrs/zustand/pull/3511

## New Contributors
* @TheSeydiCharyyev made their first contribution in https://github.com/pmndrs/zustand/pull/3487
* @brofrong made their first contribution in https://github.com/pmndrs/zustand/pull/3496
* @hyun907 made their first contribution in https://github.com/pmndrs/zustand/pull/3506

**Full Changelog**: https://github.com/pmndrs/zustand/compare/v5.0.13...v5.0.14

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter zustand && pnpm install`
- Only `package.json` and `pnpm-lock.yaml` were modified.

🤖 Generated by the `update-deps` skill.
