### PR TITLE
fix(tracker): keep PostHogProvider mounted and defer posthog init

### DIFF
--- a/__mocks__/posthog-js/index.ts
+++ b/__mocks__/posthog-js/index.ts
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type posthogJs from 'posthog-js';
+
+const posthog = {
+	init: vi.fn(),
+	__loaded: false
+} as unknown as typeof posthogJs;
+
+export default posthog;

--- a/src/boot/get-components-double-call.test.tsx
+++ b/src/boot/get-components-double-call.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Suspense } from 'react';
+
+import { act, render, waitFor } from '@testing-library/react';
+import { noop } from 'lodash';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router-dom';
+
+import Bootstrapper from './bootstrapper';
+import server from '../mocks/server';
+import { useAccountStore } from '../store/account';
+
+describe('boot network calls', () => {
+	it('fires components.json only once even when carbonioPrefSendAnalytics=TRUE arrives from GetInfo', async () => {
+		vi.spyOn(console, 'warn').mockImplementation(noop);
+		vi.spyOn(console, 'error').mockImplementation(noop);
+
+		let componentsCalls = 0;
+		server.use(
+			http.get('/static/iris/components.json', () => {
+				componentsCalls += 1;
+				return HttpResponse.json({ components: [] });
+			})
+		);
+
+		render(
+			<MemoryRouter>
+				<Suspense fallback={<div data-testid={'splash'} />}>
+					<Bootstrapper />
+				</Suspense>
+			</MemoryRouter>
+		);
+
+		await waitFor(() => expect(componentsCalls).toBe(1));
+
+		// simulate what getSessionInfo does when GetInfoResponse lands
+		// for a user that has opted into analytics
+		act(() => {
+			const current = useAccountStore.getState();
+			useAccountStore.setState({
+				authenticated: true,
+				settings: {
+					...current.settings,
+					prefs: { ...current.settings.prefs, carbonioPrefSendAnalytics: 'TRUE' }
+				}
+			});
+		});
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(500);
+		});
+
+		expect(componentsCalls).toBe(1);
+	});
+});

--- a/src/tests/posthog-utils.ts
+++ b/src/tests/posthog-utils.ts
@@ -7,8 +7,11 @@ import type { PostHogConfig } from 'posthog-js';
 import type * as PostHogReact from 'posthog-js/react';
 import { usePostHog } from 'posthog-js/react';
 
-export const spyOnPosthog = (): Partial<ReturnType<(typeof PostHogReact)['usePostHog']>> => {
+export const spyOnPosthog = ({ loaded = false }: { loaded?: boolean } = {}): Partial<
+	ReturnType<(typeof PostHogReact)['usePostHog']>
+> => {
 	const postHog = {
+		__loaded: loaded,
 		identify: vi.fn(),
 		opt_in_capturing: vi.fn(),
 		opt_out_capturing: vi.fn(),

--- a/src/tracker/provider.test.tsx
+++ b/src/tracker/provider.test.tsx
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { useEffect } from 'react';
+
 import { act } from '@testing-library/react';
 import type { AccountSettingsPrefs } from '@zextras/carbonio-ui-soap-lib';
 import type { PostHog, PostHogConfig } from 'posthog-js';
+import posthogJs from 'posthog-js';
 import { PostHogProvider } from 'posthog-js/react';
-import type * as PostHogReact from 'posthog-js/react';
 
 import { TrackerProvider } from './provider';
 import { useAccountStore } from '../store/account';
@@ -18,8 +20,11 @@ import { spyOnPosthog } from '../tests/posthog-utils';
 import { screen, setup } from '../tests/utils';
 import * as utils from '../utils/utils';
 
+type InitOptions = Partial<PostHogConfig> & { loaded?: (ph: PostHog) => void };
+
 beforeEach(() => {
 	vi.spyOn(utils, 'getCurrentLocationHost').mockReturnValue('differentHost');
+	posthogJs.__loaded = false;
 });
 
 const setSendAnalytics = (value: AccountSettingsPrefs['carbonioPrefSendAnalytics']): void => {
@@ -32,8 +37,11 @@ const setSendAnalytics = (value: AccountSettingsPrefs['carbonioPrefSendAnalytics
 	}));
 };
 
+const getInitOptions = (): InitOptions | undefined =>
+	vi.mocked(posthogJs.init).mock.lastCall?.[1] as InitOptions | undefined;
+
 describe('TrackerProvider', () => {
-	it('should mount PostHogProvider with the expected config when carbonioPrefSendAnalytics is TRUE', () => {
+	it('should init posthog with the expected config when carbonioPrefSendAnalytics is TRUE', () => {
 		setSendAnalytics('TRUE');
 		const mockProvider = vi.mocked(PostHogProvider);
 		setup(
@@ -41,23 +49,21 @@ describe('TrackerProvider', () => {
 				<div data-testid={'child'} />
 			</TrackerProvider>
 		);
-		type PostHogProviderProps = React.ComponentPropsWithoutRef<
-			(typeof PostHogReact)['PostHogProvider']
-		>;
+		expect(
+			posthogJs.init,
+			'posthog should be initialized with the privacy-preserving config and the api key when analytics is enabled'
+		).toHaveBeenLastCalledWith(
+			POSTHOG_API_KEY,
+			expect.objectContaining<Partial<PostHogConfig>>({
+				opt_out_capturing_by_default: true,
+				disable_session_recording: true,
+				disable_surveys: true
+			})
+		);
 		expect(
 			mockProvider,
-			'PostHogProvider should mount with the privacy-preserving config and the api key when analytics is enabled'
-		).toHaveBeenLastCalledWith(
-			expect.objectContaining<PostHogProviderProps>({
-				options: expect.objectContaining<NonNullable<PostHogProviderProps['options']>>({
-					opt_out_capturing_by_default: true,
-					disable_session_recording: true,
-					disable_surveys: true
-				}),
-				apiKey: POSTHOG_API_KEY
-			}),
-			expect.anything()
-		);
+			'PostHogProvider should receive the posthog singleton as client'
+		).toHaveBeenLastCalledWith(expect.objectContaining({ client: posthogJs }), expect.anything());
 		expect(
 			screen.getByTestId('child'),
 			'children should be rendered when analytics is enabled'
@@ -65,10 +71,11 @@ describe('TrackerProvider', () => {
 	});
 
 	it.each<AccountSettingsPrefs['carbonioPrefSendAnalytics']>(['FALSE', undefined])(
-		'should not mount PostHogProvider when carbonioPrefSendAnalytics is %s',
+		'should mount PostHogProvider but not init posthog when carbonioPrefSendAnalytics is %s',
 		(value) => {
 			setSendAnalytics(value);
 			const mockProvider = vi.mocked(PostHogProvider);
+			const posthog = spyOnPosthog({ loaded: true });
 			setup(
 				<TrackerProvider>
 					<div data-testid={'child'} />
@@ -76,7 +83,15 @@ describe('TrackerProvider', () => {
 			);
 			expect(
 				mockProvider,
-				`PostHogProvider should not mount when carbonioPrefSendAnalytics is ${value}`
+				'PostHogProvider should always mount to keep the tree shape stable'
+			).toHaveBeenCalled();
+			expect(
+				posthogJs.init,
+				`posthog should not be initialized when carbonioPrefSendAnalytics is ${value}`
+			).not.toHaveBeenCalled();
+			expect(
+				posthog.opt_in_capturing,
+				`PostHog should not opt-in when carbonioPrefSendAnalytics is ${value}`
 			).not.toHaveBeenCalled();
 			expect(
 				screen.getByTestId('child'),
@@ -85,21 +100,74 @@ describe('TrackerProvider', () => {
 		}
 	);
 
+	it('should not remount children when carbonioPrefSendAnalytics arrives after login', () => {
+		const onMount = vi.fn();
+		const Probe = (): null => {
+			useEffect(() => {
+				onMount();
+			}, []);
+			return null;
+		};
+		setSendAnalytics(undefined);
+		setup(
+			<TrackerProvider>
+				<Probe />
+			</TrackerProvider>
+		);
+		expect(onMount, 'children should mount once at boot').toHaveBeenCalledTimes(1);
+		act(() => {
+			setSendAnalytics('TRUE');
+		});
+		expect(
+			onMount,
+			'children must not remount when the analytics pref becomes TRUE, ' +
+				'otherwise the whole app below TrackerProvider boots twice (e.g. getComponents fires twice)'
+		).toHaveBeenCalledTimes(1);
+	});
+
+	it('should init posthog only when carbonioPrefSendAnalytics becomes TRUE, and only once', () => {
+		setSendAnalytics(undefined);
+		setup(
+			<TrackerProvider>
+				<div data-testid={'child'} />
+			</TrackerProvider>
+		);
+		expect(
+			posthogJs.init,
+			'posthog should not be initialized while the analytics pref is unknown'
+		).not.toHaveBeenCalled();
+		act(() => {
+			setSendAnalytics('TRUE');
+		});
+		expect(
+			posthogJs.init,
+			'posthog should be initialized when the analytics pref arrives as TRUE'
+		).toHaveBeenCalledTimes(1);
+		// simulate the __loaded flag set by the real posthog.init
+		posthogJs.__loaded = true;
+		act(() => {
+			setSendAnalytics('FALSE');
+		});
+		act(() => {
+			setSendAnalytics('TRUE');
+		});
+		expect(
+			posthogJs.init,
+			'posthog should not be re-initialized when the pref is toggled within the session'
+		).toHaveBeenCalledTimes(1);
+	});
+
 	it('should identify the user via the loaded callback', async () => {
 		setSendAnalytics('TRUE');
 		useAccountStore.setState({ account: mockedAccount });
-		const mockProvider = vi.mocked(PostHogProvider);
 		const posthog = spyOnPosthog();
 		setup(
 			<TrackerProvider>
 				<div data-testid={'child'} />
 			</TrackerProvider>
 		);
-		const { lastCall } = mockProvider.mock;
-		const options = lastCall?.[0].options as Partial<PostHogConfig> & {
-			loaded?: (ph: PostHog) => void;
-		};
-		options.loaded?.(posthog as unknown as PostHog);
+		const options = getInitOptions();
+		options?.loaded?.(posthog as unknown as PostHog);
 		await vi.advanceTimersByTimeAsync(0);
 		expect(
 			posthog.identify,
@@ -109,18 +177,14 @@ describe('TrackerProvider', () => {
 
 	it('should opt-in PostHog via the loaded callback (overrides any persisted opt-out state)', () => {
 		setSendAnalytics('TRUE');
-		const mockProvider = vi.mocked(PostHogProvider);
 		const posthog = spyOnPosthog();
 		setup(
 			<TrackerProvider>
 				<div data-testid={'child'} />
 			</TrackerProvider>
 		);
-		const { lastCall } = mockProvider.mock;
-		const options = lastCall?.[0].options as Partial<PostHogConfig> & {
-			loaded?: (ph: PostHog) => void;
-		};
-		options.loaded?.(posthog as unknown as PostHog);
+		const options = getInitOptions();
+		options?.loaded?.(posthog as unknown as PostHog);
 		expect(
 			posthog.opt_in_capturing,
 			'loaded callback should opt-in PostHog, overriding any persisted opt-out state'
@@ -133,18 +197,14 @@ describe('TrackerProvider', () => {
 			vi.spyOn(utils, 'getCurrentLocationHost').mockReturnValue(host);
 			setSendAnalytics('TRUE');
 			useAccountStore.setState({ account: mockedAccount });
-			const mockProvider = vi.mocked(PostHogProvider);
 			const posthog = spyOnPosthog();
 			setup(
 				<TrackerProvider>
 					<div data-testid={'child'} />
 				</TrackerProvider>
 			);
-			const { lastCall } = mockProvider.mock;
-			const options = lastCall?.[0].options as Partial<PostHogConfig> & {
-				loaded?: (ph: PostHog) => void;
-			};
-			options.loaded?.(posthog as unknown as PostHog);
+			const options = getInitOptions();
+			options?.loaded?.(posthog as unknown as PostHog);
 			expect(
 				posthog.identify,
 				`loaded callback should not identify the user when host is ${host}`
@@ -155,6 +215,38 @@ describe('TrackerProvider', () => {
 			).not.toHaveBeenCalled();
 		}
 	);
+
+	it('should not opt-in via the loaded callback if the pref was switched off while posthog was loading', () => {
+		setSendAnalytics('TRUE');
+		useAccountStore.setState({ account: mockedAccount });
+		const posthog = spyOnPosthog();
+		setup(
+			<TrackerProvider>
+				<div data-testid={'child'} />
+			</TrackerProvider>
+		);
+		expect(
+			posthogJs.init,
+			'posthog should be initialized when analytics is enabled'
+		).toHaveBeenCalled();
+		act(() => {
+			setSendAnalytics('FALSE');
+		});
+		const options = getInitOptions();
+		options?.loaded?.(posthog as unknown as PostHog);
+		expect(
+			posthog.opt_in_capturing,
+			'loaded callback should not opt-in when the pref was switched off while loading'
+		).not.toHaveBeenCalled();
+		expect(
+			posthog.identify,
+			'loaded callback should not identify the user when the pref was switched off while loading'
+		).not.toHaveBeenCalled();
+		expect(
+			posthog.setPersonProperties,
+			'loaded callback should not set person properties when the pref was switched off while loading'
+		).not.toHaveBeenCalled();
+	});
 });
 
 describe('TrackerSetup', () => {
@@ -163,8 +255,7 @@ describe('TrackerSetup', () => {
 		(isCE) => {
 			setSendAnalytics('TRUE');
 			useLoginConfigStore.setState({ isCarbonioCE: isCE });
-			const posthog = spyOnPosthog();
-			Object.assign(posthog, { __loaded: true });
+			const posthog = spyOnPosthog({ loaded: true });
 			setup(
 				<TrackerProvider>
 					<div data-testid={'child'} />
@@ -180,8 +271,7 @@ describe('TrackerSetup', () => {
 	it('should not set is_ce person property when CE state is undefined', () => {
 		setSendAnalytics('TRUE');
 		useLoginConfigStore.setState({ isCarbonioCE: undefined });
-		const posthog = spyOnPosthog();
-		Object.assign(posthog, { __loaded: true });
+		const posthog = spyOnPosthog({ loaded: true });
 		setup(
 			<TrackerProvider>
 				<div data-testid={'child'} />
@@ -216,8 +306,7 @@ describe('TrackerSetup', () => {
 	it('should enable surveys when Carbonio is CE', () => {
 		setSendAnalytics('TRUE');
 		useLoginConfigStore.setState({ isCarbonioCE: true });
-		const posthog = spyOnPosthog();
-		Object.assign(posthog, { __loaded: true });
+		const posthog = spyOnPosthog({ loaded: true });
 		setup(
 			<TrackerProvider>
 				<div data-testid={'child'} />
@@ -232,8 +321,7 @@ describe('TrackerSetup', () => {
 	it('should not call set_config when Carbonio is not CE (config already disables surveys)', () => {
 		setSendAnalytics('TRUE');
 		useLoginConfigStore.setState({ isCarbonioCE: false });
-		const posthog = spyOnPosthog();
-		Object.assign(posthog, { __loaded: true });
+		const posthog = spyOnPosthog({ loaded: true });
 		vi.mocked(posthog.config)!.disable_surveys = true;
 		setup(
 			<TrackerProvider>
@@ -249,8 +337,7 @@ describe('TrackerSetup', () => {
 	it('should re-apply config when CE state changes', () => {
 		setSendAnalytics('TRUE');
 		useLoginConfigStore.setState({ isCarbonioCE: false });
-		const posthog = spyOnPosthog();
-		Object.assign(posthog, { __loaded: true });
+		const posthog = spyOnPosthog({ loaded: true });
 		vi.mocked(posthog.config)!.disable_surveys = true;
 		setup(
 			<TrackerProvider>
@@ -273,8 +360,7 @@ describe('TrackerSetup', () => {
 	it('should NOT run setup effects when carbonioPrefSendAnalytics is FALSE', () => {
 		setSendAnalytics('FALSE');
 		useLoginConfigStore.setState({ isCarbonioCE: true });
-		const posthog = spyOnPosthog();
-		Object.assign(posthog, { __loaded: true });
+		const posthog = spyOnPosthog({ loaded: true });
 		setup(
 			<TrackerProvider>
 				<div data-testid={'child'} />
@@ -295,44 +381,43 @@ describe('TrackerSetup', () => {
 		(isCE) => {
 			setSendAnalytics('TRUE');
 			useLoginConfigStore.setState({ isCarbonioCE: isCE });
-			const mockProvider = vi.mocked(PostHogProvider);
 			const posthog = spyOnPosthog();
 			setup(
 				<TrackerProvider>
 					<div data-testid={'child'} />
 				</TrackerProvider>
 			);
-			const { lastCall } = mockProvider.mock;
-			const options = lastCall?.[0].options as Partial<PostHogConfig> & {
-				loaded?: (ph: PostHog) => void;
-			};
-			options.loaded?.(posthog as unknown as PostHog);
+			const options = getInitOptions();
+			options?.loaded?.(posthog as unknown as PostHog);
 			expect(
 				posthog.setPersonProperties,
 				`loaded callback should set is_ce person property to ${isCE}`
 			).toHaveBeenCalledWith({ is_ce: isCE });
-			expect(
-				posthog.set_config,
-				`loaded callback should configure surveys with disable_surveys ${!isCE}`
-			).toHaveBeenCalledWith({ disable_surveys: !isCE });
+			if (isCE) {
+				expect(
+					posthog.set_config,
+					'loaded callback should enable surveys when Carbonio is CE'
+				).toHaveBeenCalledWith({ disable_surveys: false });
+			} else {
+				expect(
+					posthog.set_config,
+					'loaded callback should not reconfigure surveys when the init config already disables them'
+				).not.toHaveBeenCalled();
+			}
 		}
 	);
 
 	it('should NOT apply CE state via the loaded callback when CE state is undefined', () => {
 		setSendAnalytics('TRUE');
 		useLoginConfigStore.setState({ isCarbonioCE: undefined });
-		const mockProvider = vi.mocked(PostHogProvider);
 		const posthog = spyOnPosthog();
 		setup(
 			<TrackerProvider>
 				<div data-testid={'child'} />
 			</TrackerProvider>
 		);
-		const { lastCall } = mockProvider.mock;
-		const options = lastCall?.[0].options as Partial<PostHogConfig> & {
-			loaded?: (ph: PostHog) => void;
-		};
-		options.loaded?.(posthog as unknown as PostHog);
+		const options = getInitOptions();
+		options?.loaded?.(posthog as unknown as PostHog);
 		expect(
 			posthog.setPersonProperties,
 			'loaded callback should not set is_ce person property when CE state is undefined'
@@ -345,7 +430,7 @@ describe('TrackerSetup', () => {
 
 	it('should opt-out PostHog when carbonioPrefSendAnalytics changes from TRUE to FALSE', () => {
 		setSendAnalytics('TRUE');
-		const posthog = spyOnPosthog();
+		const posthog = spyOnPosthog({ loaded: true });
 		setup(
 			<TrackerProvider>
 				<div data-testid={'child'} />
@@ -381,8 +466,7 @@ describe('TrackerSetup', () => {
 
 	it('should explicitly opt-in PostHog when singleton is already loaded (toggle FALSE → TRUE in session)', () => {
 		setSendAnalytics('TRUE');
-		const posthog = spyOnPosthog();
-		Object.assign(posthog, { __loaded: true });
+		const posthog = spyOnPosthog({ loaded: true });
 		setup(
 			<TrackerProvider>
 				<div data-testid={'child'} />
@@ -394,13 +478,39 @@ describe('TrackerSetup', () => {
 		).toHaveBeenCalled();
 	});
 
+	it('should opt-in and identify when carbonioPrefSendAnalytics becomes TRUE after posthog is loaded (boot flow)', async () => {
+		setSendAnalytics(undefined);
+		useAccountStore.setState({ account: mockedAccount });
+		const posthog = spyOnPosthog({ loaded: true });
+		setup(
+			<TrackerProvider>
+				<div data-testid={'child'} />
+			</TrackerProvider>
+		);
+		expect(
+			posthog.opt_in_capturing,
+			'PostHog should not opt-in while the analytics pref is still unknown'
+		).not.toHaveBeenCalled();
+		act(() => {
+			setSendAnalytics('TRUE');
+		});
+		expect(
+			posthog.opt_in_capturing,
+			'PostHog should opt-in when the analytics pref arrives as TRUE after load'
+		).toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(0);
+		expect(
+			posthog.identify,
+			'the user should be identified when the analytics pref arrives as TRUE after load'
+		).toHaveBeenCalledWith('mEAzl8Lcf4UJ+/uFXopfi6SaL55V61IdfIWCruI7O2Q=');
+	});
+
 	it.each(['localhost', '127.0.0.1'])(
 		'should NOT opt-in via mount effect if host is %s (even when singleton is already loaded)',
 		(host) => {
 			vi.spyOn(utils, 'getCurrentLocationHost').mockReturnValue(host);
 			setSendAnalytics('TRUE');
-			const posthog = spyOnPosthog();
-			Object.assign(posthog, { __loaded: true });
+			const posthog = spyOnPosthog({ loaded: true });
 			setup(
 				<TrackerProvider>
 					<div data-testid={'child'} />

--- a/src/tracker/provider.tsx
+++ b/src/tracker/provider.tsx
@@ -5,7 +5,8 @@
  */
 import React, { useEffect, useMemo } from 'react';
 
-import type { PostHogConfig } from 'posthog-js';
+import type { PostHog, PostHogConfig, PostHogInterface } from 'posthog-js';
+import posthogJs from 'posthog-js';
 import { PostHogProvider, usePostHog } from 'posthog-js/react';
 
 import { TrackerPageView } from './page-view';
@@ -13,30 +14,64 @@ import { identifyCurrentUser, isLocalHost } from './tracker';
 import { useAccountStore } from '../store/account';
 import { useIsCarbonioCE } from '../store/login/hooks';
 import { useLoginConfigStore } from '../store/login/store';
+import type { AccountState } from '../types/account';
+
+const sendAnalyticsSelector = (state: AccountState): boolean =>
+	state.settings.prefs.carbonioPrefSendAnalytics === 'TRUE';
+
+const isTrackerEnabled = (): boolean => sendAnalyticsSelector(useAccountStore.getState());
+
+// single source of truth for the consent → posthog state mapping, shared by the
+// loaded callback (async init path) and the TrackerSetup effects (pref-change path)
+const applyConsentState = (postHog: PostHogInterface, sendAnalytics: boolean): void => {
+	if (isLocalHost()) {
+		return;
+	}
+	if (sendAnalytics) {
+		postHog.opt_in_capturing();
+		identifyCurrentUser(postHog);
+	} else {
+		postHog.opt_out_capturing();
+	}
+};
+
+const applyCarbonioCEConfig = (
+	// the loaded callback receives a PostHogInterface, which omits config:
+	// without it the diff check degrades to an unconditional set_config
+	postHog: PostHogInterface & Partial<Pick<PostHog, 'config'>>,
+	isCarbonioCE: boolean | undefined
+): void => {
+	if (isCarbonioCE === undefined) {
+		return;
+	}
+	postHog.setPersonProperties({ is_ce: isCarbonioCE });
+	const disableSurveys = !isCarbonioCE;
+	if (postHog.config?.disable_surveys !== disableSurveys) {
+		postHog.set_config({ disable_surveys: disableSurveys });
+	}
+};
 
 const TrackerSetup = (): null => {
 	const postHog = usePostHog();
 	const isCarbonioCE = useIsCarbonioCE();
+	const sendAnalytics = useAccountStore(sendAnalyticsSelector);
 
 	useEffect(() => {
-		if (postHog.__loaded && !isLocalHost()) {
-			postHog.opt_in_capturing();
+		if (!postHog.__loaded) {
+			return undefined;
 		}
+		applyConsentState(postHog, sendAnalytics);
 		return () => {
 			postHog.opt_out_capturing();
 		};
-	}, [postHog]);
+	}, [postHog, sendAnalytics]);
 
 	useEffect(() => {
-		if (!postHog.__loaded || isCarbonioCE === undefined) {
+		if (!postHog.__loaded || !sendAnalytics) {
 			return;
 		}
-		postHog.setPersonProperties({ is_ce: isCarbonioCE });
-		const newValue = !isCarbonioCE;
-		if (postHog.config.disable_surveys !== newValue) {
-			postHog.set_config({ disable_surveys: newValue });
-		}
-	}, [isCarbonioCE, postHog]);
+		applyCarbonioCEConfig(postHog, isCarbonioCE);
+	}, [isCarbonioCE, postHog, sendAnalytics]);
 
 	return null;
 };
@@ -44,9 +79,7 @@ const TrackerSetup = (): null => {
 export const TrackerProvider = ({
 	children
 }: React.PropsWithChildren<Record<never, never>>): React.JSX.Element => {
-	const carbonioPrefSendAnalytics = useAccountStore(
-		(state) => state.settings.prefs.carbonioPrefSendAnalytics
-	);
+	const sendAnalytics = useAccountStore(sendAnalyticsSelector);
 
 	const options = useMemo(
 		(): Partial<PostHogConfig> => ({
@@ -60,26 +93,30 @@ export const TrackerProvider = ({
 			capture_pageleave: true,
 			autocapture: false,
 			loaded: (postHog): void => {
-				if (!isLocalHost()) {
-					postHog.opt_in_capturing();
+				// init is requested only on consent, but the pref may have been
+				// switched off again while posthog was still loading
+				if (!isTrackerEnabled()) {
+					return;
 				}
-				identifyCurrentUser(postHog);
-				const { isCarbonioCE } = useLoginConfigStore.getState();
-				if (isCarbonioCE !== undefined) {
-					postHog.setPersonProperties({ is_ce: isCarbonioCE });
-					postHog.set_config({ disable_surveys: !isCarbonioCE });
-				}
+				applyConsentState(postHog, true);
+				applyCarbonioCEConfig(postHog, useLoginConfigStore.getState().isCarbonioCE);
 			}
 		}),
 		[]
 	);
 
-	if (carbonioPrefSendAnalytics !== 'TRUE') {
-		return <>{children}</>;
-	}
+	useEffect(() => {
+		// deferred init: posthog stays completely inert (no cookies, no requests)
+		// for users who did not opt into analytics. The provider is always mounted
+		// to keep the tree shape stable: a conditional wrapper would remount the
+		// whole app when the settings arrive after login
+		if (sendAnalytics && !posthogJs.__loaded) {
+			posthogJs.init(POSTHOG_API_KEY, options);
+		}
+	}, [sendAnalytics, options]);
 
 	return (
-		<PostHogProvider apiKey={POSTHOG_API_KEY} options={options}>
+		<PostHogProvider client={posthogJs}>
 			<TrackerSetup />
 			{children}
 			<TrackerPageView />

--- a/src/tracker/tracker.test.ts
+++ b/src/tracker/tracker.test.ts
@@ -18,7 +18,7 @@ beforeEach(() => {
 
 describe('useTracker', () => {
 	it('should opt-in posthog if host is not localhost and enableTracker is called with true value', () => {
-		const posthog = spyOnPosthog();
+		const posthog = spyOnPosthog({ loaded: true });
 		const { result } = renderHook(() => useTracker());
 		act(() => {
 			result.current.enableTracker(true);
@@ -31,7 +31,7 @@ describe('useTracker', () => {
 
 	it.each(['localhost', '127.0.0.1'])('should not opt-in posthog if host is %s', (host) => {
 		vi.spyOn(utils, 'getCurrentLocationHost').mockReturnValue(host);
-		const posthog = spyOnPosthog();
+		const posthog = spyOnPosthog({ loaded: true });
 		const { result } = renderHook(() => useTracker());
 		result.current.enableTracker(true);
 		expect(
@@ -41,7 +41,7 @@ describe('useTracker', () => {
 	});
 
 	it('should opt-out posthog if enableTracker is called with false value', () => {
-		const posthog = spyOnPosthog();
+		const posthog = spyOnPosthog({ loaded: true });
 		const { result } = renderHook(() => useTracker());
 		act(() => {
 			result.current.enableTracker(false);
@@ -53,14 +53,14 @@ describe('useTracker', () => {
 	});
 
 	it('should reset posthog if reset function is called', () => {
-		const posthog = spyOnPosthog();
+		const posthog = spyOnPosthog({ loaded: true });
 		const { result } = renderHook(() => useTracker());
 		result.current.reset();
 		expect(posthog.reset, 'reset() should reset PostHog').toHaveBeenCalled();
 	});
 
 	it('should call capture ', () => {
-		const posthog = spyOnPosthog();
+		const posthog = spyOnPosthog({ loaded: true });
 		const { result } = renderHook(() => useTracker());
 		const eventName = 'event name';
 		const properties = { prop1: 'prop1value', prop2: 'prop2value' };
@@ -74,7 +74,7 @@ describe('useTracker', () => {
 
 	it('should identify user through its hashed id when enabling the tracker for an authenticated account', async () => {
 		useAccountStore.setState({ account: mockedAccount });
-		const posthog = spyOnPosthog();
+		const posthog = spyOnPosthog({ loaded: true });
 		const { result } = renderHook(() => useTracker());
 		act(() => {
 			result.current.enableTracker(true);
@@ -88,7 +88,7 @@ describe('useTracker', () => {
 
 	it('should not identify user if no user is authenticated', () => {
 		useAccountStore.setState({ account: undefined });
-		const posthog = spyOnPosthog();
+		const posthog = spyOnPosthog({ loaded: true });
 		const { result } = renderHook(() => useTracker());
 		act(() => {
 			result.current.enableTracker(true);
@@ -96,6 +96,34 @@ describe('useTracker', () => {
 		expect(
 			posthog.identify,
 			'enableTracker should not identify the user when no account is authenticated'
+		).not.toHaveBeenCalled();
+	});
+
+	it('should be a silent no-op when posthog is not initialized (deferred init without consent)', () => {
+		const posthog = spyOnPosthog();
+		// __loaded is undefined on the stub → simulates the singleton before posthog.init
+		const { result } = renderHook(() => useTracker());
+		act(() => {
+			result.current.enableTracker(true);
+			result.current.enableTracker(false);
+			result.current.capture('event');
+			result.current.reset();
+		});
+		expect(
+			posthog.opt_in_capturing,
+			'enableTracker(true) should not opt in before posthog is initialized'
+		).not.toHaveBeenCalled();
+		expect(
+			posthog.opt_out_capturing,
+			'enableTracker(false) should not opt out before posthog is initialized'
+		).not.toHaveBeenCalled();
+		expect(
+			posthog.capture,
+			'capture() should not forward events before posthog is initialized'
+		).not.toHaveBeenCalled();
+		expect(
+			posthog.reset,
+			'reset() should not reset before posthog is initialized'
 		).not.toHaveBeenCalled();
 	});
 });

--- a/src/tracker/tracker.tsx
+++ b/src/tracker/tracker.tsx
@@ -56,7 +56,9 @@ export const useTracker = (): Tracker => {
 
 	const enableTracker = useCallback(
 		(enable: boolean) => {
-			if (isLocalHost()) {
+			// posthog is initialized only after the user opts into analytics:
+			// before that every call must be a silent no-op
+			if (!postHog.__loaded || isLocalHost()) {
 				return;
 			}
 			if (enable) {
@@ -70,11 +72,17 @@ export const useTracker = (): Tracker => {
 	);
 
 	const reset = useCallback(() => {
+		if (!postHog.__loaded) {
+			return;
+		}
 		postHog.reset();
 	}, [postHog]);
 
 	const capture = useCallback<Tracker['capture']>(
 		(eventName, properties, options) => {
+			if (!postHog.__loaded) {
+				return;
+			}
 			postHog.capture(eventName, properties, options);
 		},
 		[postHog]

--- a/src/vitest-env-setup.ts
+++ b/src/vitest-env-setup.ts
@@ -129,6 +129,8 @@ vi.mock('@zextras/carbonio-ui-preview', () => ({
 	PreviewManager: ({ children }: React.PropsWithChildren): React.ReactNode => children
 }));
 
+vi.mock('posthog-js');
+
 vi.mock('posthog-js/react');
 
 vi.mock('darkreader');


### PR DESCRIPTION
## Problem

Since the tracker refactor in #800 (CO-3507), `TrackerProvider` wrapped its children in `PostHogProvider` only when `carbonioPrefSendAnalytics` is `TRUE`. At boot the pref is still unknown, so children render in a bare fragment; when `GetInfoResponse` arrives and sets the pref to `TRUE`, the wrapper element type changes and React unmounts and remounts the whole subtree below `TrackerProvider` (`Loader`, `ShellView`, `AppLoaderMounter`).

For users who opted into analytics, every boot fired `components.json`, `loginConfig` and `GetInfoRequest` **twice**, and all modules were unloaded and reloaded.

## Solution

- `PostHogProvider` is now **always mounted** with the posthog singleton via the `client` prop, so the tree shape never changes and nothing remounts when the settings arrive.
- `posthog.init()` is **deferred** into a consent-gated effect: posthog stays completely inert (no cookies, no requests) for users who did not opt in, preserving the privacy intent of CO-3507.
- The consent → posthog state mapping is consolidated in two shared helpers (`applyConsentState`, `applyCarbonioCEConfig`) used by both the `loaded` callback (async init path) and the `TrackerSetup` effects (pref-change path).
- `useTracker` methods (`capture`, `reset`, `enableTracker`) are silent no-ops until posthog is initialized, so consumers (e.g. `TrackerPageView`, modules importing `useTracker`) are safe pre-init.

## Tests

- New regression test: children must not remount when the analytics pref arrives after login.
- New boot-level test: `components.json` is requested only once across the settings flip.
- New tests for deferred init (no init without consent, init once, opt-in race while loading).
- `spyOnPosthog` now accepts a `{ loaded }` option, replacing the repeated `Object.assign` boilerplate.
- New global vitest mock for `posthog-js` (`__mocks__/posthog-js/index.ts`).

Refs: [CO-3847](https://zextras.atlassian.net/browse/CO-3847)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CO-3847]: https://zextras.atlassian.net/browse/CO-3847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ