### PR TITLE
fix(shell): hide modules whose feature attribute is not enabled

### DIFF
--- a/src/boot/app/load-apps.test.ts
+++ b/src/boot/app/load-apps.test.ts
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { isAppEnabled } from './load-apps';
+import { normalizeApp } from '../../store/app/utils';
+import { setupAccountStore } from '../../tests/account-utils';
+
+const ATTR_KEY = 'carbonioFeatureTasksEnabled';
+
+describe('isAppEnabled', () => {
+	it.each([undefined, ''])('should enable a module whose attrKey is %j', (attrKey) => {
+		setupAccountStore({ accountSettingsAttrs: {} });
+		expect(
+			isAppEnabled(normalizeApp({ name: 'carbonio-tasks-ui', attrKey })),
+			`a module without a declared attrKey should be enabled, since there is no attribute to read`
+		).toBe(true);
+	});
+
+	it.each(['TRUE', 'true'])('should enable a module whose attribute is %s', (value) => {
+		setupAccountStore({ accountSettingsAttrs: { [ATTR_KEY]: value } });
+		expect(
+			isAppEnabled(normalizeApp({ name: 'carbonio-tasks-ui', attrKey: ATTR_KEY })),
+			`a module should be enabled when ${ATTR_KEY} is ${value}`
+		).toBe(true);
+	});
+
+	it.each(['FALSE', 'false'])('should not enable a module whose attribute is %s', (value) => {
+		setupAccountStore({ accountSettingsAttrs: { [ATTR_KEY]: value } });
+		expect(
+			isAppEnabled(normalizeApp({ name: 'carbonio-tasks-ui', attrKey: ATTR_KEY })),
+			`a module should not be enabled when ${ATTR_KEY} is ${value}`
+		).toBe(false);
+	});
+
+	it('should not enable a module whose attribute is empty', () => {
+		setupAccountStore({ accountSettingsAttrs: { [ATTR_KEY]: '' } });
+		expect(
+			isAppEnabled(normalizeApp({ name: 'carbonio-tasks-ui', attrKey: ATTR_KEY })),
+			`a module should not be enabled when ${ATTR_KEY} has no value`
+		).toBe(false);
+	});
+
+	it('should not enable a module whose attribute is missing', () => {
+		setupAccountStore({ accountSettingsAttrs: {} });
+		expect(
+			isAppEnabled(normalizeApp({ name: 'carbonio-tasks-ui', attrKey: ATTR_KEY })),
+			`a module should not be enabled when ${ATTR_KEY} is not returned at all`
+		).toBe(false);
+	});
+});

--- a/src/boot/app/load-apps.ts
+++ b/src/boot/app/load-apps.ts
@@ -15,13 +15,19 @@ import { getUserSetting, useAccountStore } from '../../store/account';
 import { useI18nStore } from '../../store/i18n/store';
 import type { CarbonioModule } from '../../types/apps';
 
+export function isAppEnabled(app: CarbonioModule): boolean {
+	// without an attrKey there is no back-end attribute to read: the module stays visible
+	if (!app.attrKey) return true;
+	return String(getUserSetting('attrs', app.attrKey)).toUpperCase() === 'TRUE';
+}
+
 export function loadApps(
 	apps: Array<CarbonioModule>
 ): Promise<PromiseSettledResult<CarbonioModule>[]> {
 	injectSharedLibraries();
 	const appsToLoad = filter(apps, (app) => {
 		if (app.name === SHELL_APP_ID) return false;
-		return !(app.attrKey && getUserSetting('attrs', app.attrKey) === 'FALSE');
+		return isAppEnabled(app);
 	});
 	// eslint-disable-next-line no-console
 	console.log(


### PR DESCRIPTION

## Truth table


| # | `attrKey` in package.json → getComponents | Value from GetInfo | Before | After |
|---|---|---|---|---|
| 1 | not declared | — (no back-end attribute to read) | ✅ loads | ✅ loads (unchanged) |
| 2 | declared | `false` | ❌ does not load | ❌ does not load (unchanged) |
| 3 | declared | `true` | ✅ loads | ✅ loads (unchanged) |
| 4 | declared | empty / attribute missing | ✅ loads | ❌ **does not load** (only change) |

Case 4 is the only change: it amounts to a `false` default, but **only** for modules that declare a key. Case 1 stays permissive on purpose, so front-end-only extensions — which have no back-end attribute — keep working.

