### PR TITLE
chore(deps): update dependency zextras/jenkins-lib-common to v4.1.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@v4.1.4',
+    identifier: 'jenkins-lib-common@v4.2.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@v2.11.3',
+    identifier: 'jenkins-lib-common@v4.1.4',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
Bumps `jenkins-lib-common` pin to `v4.1.4`.

- Pin-only bump: repo is already on `v2.11.3` (>= `v2.0.0`), so the trunk-based branch-guard change does not apply.
- `uiPipeline()` is called with no parameters — no `testScript` to remove, `sonarProjectKey` not needed.
- No `uploadStage(packages:)` usage in this repo.
- `uiPipeline` provisions its own pod (`nodejs-v1`, which has a `gitleaks` container) — no pod/agent changes needed.

Refs https://zextras.atlassian.net/browse/IN-1168