### PR TITLE
fix(ci): cap vitest forks to 2 to prevent k8s CPU saturation

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	},
 	"scripts": {
 		"bump-version": "semantic-release",
-		"test:ci": "vitest run --reporter=default --reporter=junit --coverage --maxWorkers=50%",
+		"test:ci": "vitest run --reporter=default --reporter=junit --coverage --maxWorkers=2",
 		"test:dev": "vitest run --no-coverage --reporter=default",
 		"test": "is-ci && pnpm run test:ci || pnpm run test:dev",
 		"test:watch": "vitest --changed",


### PR DESCRIPTION
## Problem

vitest 4.x switched the default worker pool from `threads` to `forks`. In forks mode, `os.availableParallelism()` returns the node's physical core count rather than the pod's CPU limit. `--maxWorkers=50%` in `test:ci` scaled off the host, so one CI pod could consume 12-13 cores; three concurrent pods saturated a 15-core k8s cluster for ~1.5h and grew the Jenkins queue to 61+ items.

## Fix

This repo uses vitest **4.1.10** with `pool: 'forks'` (set in `vitest.config.ts`). The deprecated `--pool-options.forks.maxForks` flag no longer works in vitest 4; the correct top-level flag is `--maxWorkers`.

Replaced `--maxWorkers=50%` with `--maxWorkers=2` in the `test:ci` script (single-package repo, no turbo/monorepo concerns; Jenkinsfile calls `uiPipeline()` with no `testScript` override, and the `test` script itself gates to `test:ci` under `is-ci`).

Ref: IN-1154 (https://zextras.atlassian.net/browse/IN-1154)
