### PR TITLE
fix: let guests load feature-gated modules on focus-mode routes

### DIFF
--- a/src/boot/app/load-apps.test.ts
+++ b/src/boot/app/load-apps.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { isAppEnabled } from './load-apps';
+import { useAccountStore } from '../../store/account';
 import { normalizeApp } from '../../store/app/utils';
 import { setupAccountStore } from '../../tests/account-utils';
 
@@ -49,5 +50,14 @@ describe('isAppEnabled', () => {
 			isAppEnabled(normalizeApp({ name: 'carbonio-tasks-ui', attrKey: ATTR_KEY })),
 			`a module should not be enabled when ${ATTR_KEY} is not returned at all`
 		).toBe(false);
+	});
+
+	it('should enable a module whose attribute is missing when there is no account', () => {
+		setupAccountStore({ accountSettingsAttrs: {} });
+		useAccountStore.setState({ account: undefined });
+		expect(
+			isAppEnabled(normalizeApp({ name: 'carbonio-tasks-ui', attrKey: ATTR_KEY })),
+			`a module should be enabled when there is no account to read ${ATTR_KEY} from`
+		).toBe(true);
 	});
 });

--- a/src/boot/app/load-apps.test.ts
+++ b/src/boot/app/load-apps.test.ts
@@ -5,13 +5,20 @@
  */
 
 import { isAppEnabled } from './load-apps';
+import * as constants from '../../constants';
 import { useAccountStore } from '../../store/account';
 import { normalizeApp } from '../../store/app/utils';
 import { setupAccountStore } from '../../tests/account-utils';
 
+vi.mock('../../constants');
+
 const ATTR_KEY = 'carbonioFeatureTasksEnabled';
 
 describe('isAppEnabled', () => {
+	beforeEach(() => {
+		vi.mocked(constants).IS_FOCUS_MODE = false;
+	});
+
 	it.each([undefined, ''])('should enable a module whose attrKey is %j', (attrKey) => {
 		setupAccountStore({ accountSettingsAttrs: {} });
 		expect(
@@ -52,12 +59,22 @@ describe('isAppEnabled', () => {
 		).toBe(false);
 	});
 
-	it('should enable a module whose attribute is missing when there is no account', () => {
+	it('should enable a module whose attribute is missing when there is no account in focus mode', () => {
+		vi.mocked(constants).IS_FOCUS_MODE = true;
 		setupAccountStore({ accountSettingsAttrs: {} });
 		useAccountStore.setState({ account: undefined });
 		expect(
 			isAppEnabled(normalizeApp({ name: 'carbonio-tasks-ui', attrKey: ATTR_KEY })),
-			`a module should be enabled when there is no account to read ${ATTR_KEY} from`
+			`a guest module should be enabled when there is no account to read ${ATTR_KEY} from`
 		).toBe(true);
+	});
+
+	it('should not enable a module whose attribute is missing when there is no account outside focus mode', () => {
+		setupAccountStore({ accountSettingsAttrs: {} });
+		useAccountStore.setState({ account: undefined });
+		expect(
+			isAppEnabled(normalizeApp({ name: 'carbonio-tasks-ui', attrKey: ATTR_KEY })),
+			`a module should stay gated outside focus mode, where an unusable session leads to login`
+		).toBe(false);
 	});
 });

--- a/src/boot/app/load-apps.ts
+++ b/src/boot/app/load-apps.ts
@@ -18,6 +18,9 @@ import type { CarbonioModule } from '../../types/apps';
 export function isAppEnabled(app: CarbonioModule): boolean {
 	// without an attrKey there is no back-end attribute to read: the module stays visible
 	if (!app.attrKey) return true;
+	// without an account no GetInfo populated the settings (guest on a focus-mode route):
+	// a per-user feature attribute is not applicable, so it cannot be used to hide the module
+	if (!useAccountStore.getState().account) return true;
 	return String(getUserSetting('attrs', app.attrKey)).toUpperCase() === 'TRUE';
 }
 

--- a/src/boot/app/load-apps.ts
+++ b/src/boot/app/load-apps.ts
@@ -9,7 +9,7 @@ import { filter, map } from 'lodash';
 
 import { loadApp, unloadApps } from './load-app';
 import { injectSharedLibraries } from './shared-libraries';
-import { SHELL_APP_ID } from '../../constants';
+import { IS_FOCUS_MODE, SHELL_APP_ID } from '../../constants';
 import { DATE_FNS_LOCALE } from '../../constants/locales';
 import { getUserSetting, useAccountStore } from '../../store/account';
 import { useI18nStore } from '../../store/i18n/store';
@@ -18,9 +18,8 @@ import type { CarbonioModule } from '../../types/apps';
 export function isAppEnabled(app: CarbonioModule): boolean {
 	// without an attrKey there is no back-end attribute to read: the module stays visible
 	if (!app.attrKey) return true;
-	// without an account no GetInfo populated the settings (guest on a focus-mode route):
-	// a per-user feature attribute is not applicable, so it cannot be used to hide the module
-	if (!useAccountStore.getState().account) return true;
+	// in focus mode a guest has no account, so no GetInfo populated the settings
+	if (IS_FOCUS_MODE && !useAccountStore.getState().account) return true;
 	return String(getUserSetting('attrs', app.attrKey)).toUpperCase() === 'TRUE';
 }
 


### PR DESCRIPTION
An unauthenticated guest opening a focus-mode link such as `/carbonio/focus-mode/meetings/<id>` never reached the page: the shell hung on a spinner. For a guest the GetInfo answers `service.AUTH_REQUIRED`, so the account settings are never populated and every module declaring an `attrKey` was dropped, including `carbonio-ws-collaboration-ui`. With no module loaded its route was never registered and `app-view-container` fell through to its spinner fallback.

`isAppEnabled` now skips the attribute check when there is no account: without a session no GetInfo populated the settings, so a per-user feature attribute is not missing but inapplicable, and it cannot be used to hide the module.