### PR TITLE
fix(ci): run Docker build stages as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM --platform=$BUILDPLATFORM docker.io/backplane/jq:latest AS builder
 
+# The base image defaults to the unprivileged "nobody" user, which cannot write under /opt
+USER root
+
 # Define path variables
 ENV IRIS_BASE_PATH="/opt/zextras/web/iris" \
     WEB_PATH="/opt/zextras/web/iris/carbonio-shell-ui"
@@ -16,6 +19,9 @@ RUN COMMIT_ID=$(jq -r .commit /tmp/dist/component.json) \
 
 # Final stage - built for all target platforms
 FROM docker.io/backplane/jq:latest
+
+# The entrypoint writes components.json under /opt, so it needs root too
+USER root
 
 # Re-define path variable for final stage
 ENV IRIS_BASE_PATH="/opt/zextras/web/iris"


### PR DESCRIPTION
## Problem

The Docker build fails:

```
mkdir: can't create directory '/opt/zextras/': Permission denied
```

`backplane/jq:latest` now runs as the unprivileged `nobody` user (`docker image inspect` → `Config.User: nobody`), so the builder stage cannot create directories under `/opt`.

Nothing changed on our side — the base image tag is not pinned, so this broke spontaneously when the upstream image was rebuilt.

## Fix

`USER root` in both stages:

- **builder stage** — needs to create `/opt/zextras/web/iris/<component>/<commit>`.
- **final stage** — the `ENTRYPOINT` writes `${IRIS_BASE_PATH}/components.json` into a directory copied from the builder as `root:root`; running as `nobody` it would fail at runtime instead of at build time.

## Verification

Verified locally against this Dockerfile:

- `docker build` completes successfully.
- The container `ENTRYPOINT` exits 0 and produces a valid `components.json` containing the expected commit id.
- The resulting layout under `/opt/zextras/web/iris/` is unchanged from what the image produced before the base image regression.

## Scope

The same regression affects every iris component image. The identical fix is being opened on:

`carbonio-shell-ui`, `carbonio-mails-ui`, `carbonio-contacts-ui`, `carbonio-calendars-ui`, `carbonio-files-ui`, `carbonio-tasks-ui`, `carbonio-search-ui`, `carbonio-auth-ui`, `carbonio-storages-ui`, `carbonio-ws-collaboration-ui`.

`carbonio-admin-console-ui` is **not** affected: it has no `RUN` step and no entrypoint, and `COPY` is performed by BuildKit as root regardless of the image's `USER`.

## Follow-up (not in this PR)

`backplane/jq:latest` being unpinned is the root cause of the spontaneous breakage. Pinning a digest — or switching to `alpine` + `apk add jq`, as `carbonio-login-ui` already does — would prevent a repeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
