### PR TITLE
chore: point semantic-release at main branch

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -8,7 +8,7 @@
  * @type {import('semantic-release').GlobalConfig}
  */
 export default {
-	branches: ['devel'],
+	branches: ['main'],
 	plugins: [
 		[
 			'@semantic-release/commit-analyzer',


### PR DESCRIPTION
Part of the GitHub default-branch rename (devel → main, old main → legacy-main), group 2 (UI apps).

`release.config.mjs` had `branches: ['devel']` hardcoded. Updated to `branches: ['main']` so semantic-release keeps releasing after the branch rename.

Merge at/after the rename window to avoid a release gap.