### PR TITLE
ci: bump a patch on dependency chore commits

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -15,13 +15,18 @@ export default {
 			{
 				preset: 'conventionalcommits',
 				releaseRules: [
-					// breaking changes must be first, otherwise a type rule (e.g. refactor→patch) would match first and suppress the major bump
+					// the breaking rule is required: as soon as a custom rule matches (e.g. refactor→patch) the default
+					// rules are no longer evaluated, so without it a breaking refactor would only get a patch
 					{ breaking: true, release: 'major' },
 					// enable release also for refactor and build commits
 					{ type: 'refactor', release: 'patch' },
 					{ type: 'build', release: 'patch' },
 					{ type: 'ci', release: 'patch' },
-					{ type: 'perf', release: 'patch' }
+					{ type: 'perf', release: 'patch' },
+					// dependency bumps change the published artifact, so they deserve a patch;
+					// the scope is required: a bare `chore:` has scope null and never matches these rules
+					{ type: 'chore', scope: 'deps', release: 'patch' },
+					{ type: 'chore', scope: 'deps-dev', release: 'patch' }
 				]
 			}
 		],
@@ -59,6 +64,20 @@ export default {
 						},
 						{
 							type: 'ci',
+							section: 'Other changes',
+							hidden: false
+						},
+						// only the dependency scopes are listed, so every other chore (chore(release) included)
+						// finds no entry and stays out of the changelog
+						{
+							type: 'chore',
+							scope: 'deps',
+							section: 'Other changes',
+							hidden: false
+						},
+						{
+							type: 'chore',
+							scope: 'deps-dev',
 							section: 'Other changes',
 							hidden: false
 						}


### PR DESCRIPTION
## Why

`release.config.mjs` enables releases for `feat`, `fix` (default rules) and `refactor`, `build`, `ci`, `perf` (custom rules). `chore` commits get nothing.

But dependency updates land as `chore(deps)` / `chore(deps-dev)` — 76 of the last 300 commits, between Renovate and the weekly updates — and they **change the published artifact**: runtime bundle and build tooling. Today they sit on `main` until an unrelated `feat`/`fix` drags them into a release, so a published version can carry different dependencies from the previous one without the version number saying so.

## What changes

Two rules in `releaseRules`:

```js
{ type: 'chore', scope: 'deps', release: 'patch' },
{ type: 'chore', scope: 'deps-dev', release: 'patch' }
```

plus the matching entries in `presetConfig.types`, so a release triggered only by dependency bumps does not produce an empty changelog entry. The preset supports `scope` in the `types` list too (`findTypeEntry` matches type **and** scope), so only these two show up and every other `chore` stays out.

The scope is required on both sides: a bare `chore:` is parsed with `scope: null` and never matches a rule that specifies one. So `chore(release)`, `chore(ci)` and unscoped chores stay inert and invisible — by construction, not through an exclusion rule.

The comment on the `breaking` rule is also corrected. It claimed the rule has to come first; since `commit-analyzer@13` the highest release type among all matching rules wins, so its position is irrelevant. What actually matters is that the rule exists, because as soon as a custom rule matches, the default rules are no longer evaluated.

## Verification

An offline script calling the plugins directly with synthetic commits — no network, no token, no dry run touching the remote.

`analyzeCommits`, 8 cases out of 8:

| commit | expected |
|---|---|
| `chore(deps): …` | `patch` |
| `chore(deps-dev): …` | `patch` |
| `chore(release): 15.2.0 [skip ci]` | no release |
| `chore: …` | no release |
| `chore(ci): …` | no release |
| `fix:` / `feat:` / breaking `refactor` | `patch` / `minor` / `major` |

Changelog filtering, by calling the preset's `transform`: both `chore(deps*)` land in `Other changes`, the other chores are discarded, and the pre-existing types are unchanged.

`prettier --check` passes. `eslint` reports only `no-template-curly-in-string` on the `message: 'chore(release): ${nextRelease.version}…'` line, which is pre-existing and outside the `lint` script, which targets `src`.

> [!NOTE]
> Seeing the generated notes requires #898, which unblocks `generateNotes` (preset `conventionalcommits@10` vs `conventional-changelog-writer@8`). The two PRs touch disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
