### PR TITLE
chore(renovate): rebase open PRs when behind base branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>zextras/infra-renovate-config",
-    "github>zextras/infra-renovate-config:docker",
-    "github>zextras/infra-renovate-config:javascript"
-  ]
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"github>zextras/infra-renovate-config",
+		"github>zextras/infra-renovate-config:docker",
+		"github>zextras/infra-renovate-config:javascript"
+	],
+	"rebaseWhen": "behind-base-branch"
 }


### PR DESCRIPTION
## What
Add `"rebaseWhen": "behind-base-branch"` to `.github/renovate.json`.

## Why
Renovate's default `rebaseWhen` (`"auto"`) only resolves to `"behind-base-branch"` for PRs that have automerge enabled. Every other open Renovate PR here (runtime dependency bumps, majors — see the shared `automerge.json` preset for what *is* automerged) resolves to `"conflicted"` instead: Renovate only rebases those branches once GitHub has already flagged a conflict, at the next scheduled run.

In practice this meant that merging one Renovate PR routinely left sibling PRs conflicting on `pnpm-lock.yaml`, requiring a manual rebase (or a wait for the next scheduled Renovate run) before they could be merged.

Setting `rebaseWhen` explicitly to `"behind-base-branch"` makes Renovate regenerate (not git-merge) every open branch — lockfile included — on every run where `main` has moved, so the lockfile conflict is avoided before it appears instead of being reacted to afterwards. This is the pattern documented by Renovate itself for this exact scenario (see [noise-reduction docs](https://docs.renovatebot.com/noise-reduction/#lock-files)).

Trade-off: open Renovate PRs will get rebased (and re-run CI) more often, whenever `main` changes, not only right before merge.

Scope: this override is local to `carbonio-shell-ui` only; the shared `zextras/infra-renovate-config` preset is left untouched, so other Carbonio projects keep the current default behavior.

## Verification
- JSON validated locally (`jq . .github/renovate.json`).
- Functional check post-merge: after this merges, when two Renovate PRs are open in parallel and one is merged, the other should pick up an automatic rebase commit from Renovate (no more "conflict" badge) by the next scheduled run, instead of staying conflicted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)