### PR TITLE
chore(renovate): weekly devDependencies bundle, dashboard approval for runtime minors

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,22 @@
 		"github>zextras/infra-renovate-config:docker",
 		"github>zextras/infra-renovate-config:javascript"
 	],
-	"rebaseWhen": "behind-base-branch"
+	"rebaseWhen": "behind-base-branch",
+	"packageRules": [
+		{
+			"description": "Runtime minor/patch updates are bundled weekly by the update-deps skill: keep them listed in the Dependency Dashboard and open a PR only on demand",
+			"matchManagers": ["npm"],
+			"matchDepTypes": ["dependencies"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"dependencyDashboardApproval": true
+		},
+		{
+			"description": "One weekly auto-merged devDependencies bundle instead of one PR (and one patch release) per package",
+			"matchManagers": ["npm"],
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"groupName": "devDependencies (weekly)",
+			"schedule": ["before 6am on monday"]
+		}
+	]
 }


### PR DESCRIPTION
## Why

Renovate and the weekly `update-deps` bundles currently overlap:

- every runtime minor/patch (e.g. `posthog-js`) gets a single-package Renovate PR that is then closed by hand once the weekly bundle lands (#881, #887–#889), and Renovate skips that version afterwards;
- every auto-merged devDependency PR is now a separate commit on `main`, and since #899 each `chore(deps)` commit publishes a patch release — five auto-merges in a week would mean five releases for tooling that never ships.

## What changes

Two repo-level `packageRules`, applied **on top of** `zextras/infra-renovate-config` (later rules only refine the preset, nothing is removed):

| Rule | Matches | Effect |
|---|---|---|
| Runtime minor/patch | `npm` manager, `dependencies` block, `minor`/`patch` | `dependencyDashboardApproval: true` — no automatic PR; the update stays listed in the Dependency Dashboard (#705) with a checkbox. The weekly runtime bundle from `update-deps` becomes the normal path, the Dashboard the on-demand fallback. |
| devDependencies minor/patch | `npm` manager, `devDependencies` block, `minor`/`patch` | `groupName: "devDependencies (weekly)"` + `schedule: before 6am on monday` — one grouped PR per week instead of one per package. Automerge is inherited from the preset rule, so one commit and one patch release per week. |

## What does not change

- **Security fixes**: `vulnerabilityAlerts` defaults to `dependencyDashboardApproval: false` and `prCreation: immediate`, so `fix(deps): … [SECURITY]` PRs like #896 keep opening right away.
- **Major updates**, **lock file maintenance** (Monday before 6am, auto-merged), **Docker** and **`zextras/jenkins-lib-*`** updates, and the `packageManager` field: not matched by either rule.
- The preset's family groups (Vitest, Testing Library, Webpack, Babel…) fold into the weekly devDependencies group; their runtime members (e.g. `react`, `react-dom`) stay in their preset group and fall under the first rule.

## Validation

```
npx --yes --package renovate -- renovate-config-validator .github/renovate.json
 INFO: Validating .github/renovate.json as global config
 INFO: Config validated successfully
```

Operational note: with these rules in place there is no reason to close Renovate PRs by hand anymore — merging a bundle makes Renovate rebase and auto-close the superseded PR on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
