### PR TITLE
chore(deps): weekly dependencies update 2026-09-09

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"i18next-http-backend": "3.0.6",
 		"immer": "11.1.18",
 		"lodash": "4.18.1",
-		"posthog-js": "1.427.2",
+		"posthog-js": "1.428.10",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
 		"react-i18next": "12.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: 4.18.1
         version: 4.18.1
       posthog-js:
-        specifier: 1.427.2
-        version: 1.427.2(@types/react@18.3.31)(react@18.3.1)
+        specifier: 1.428.10
+        version: 1.428.10(@types/react@18.3.31)(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -1696,14 +1696,14 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@posthog/browser-common@0.7.2':
-    resolution: {integrity: sha512-ukDmETXy6fTBE4ZpaO8ccscrNz5SvTaUnhQ0Ze2JX/oYILa89rrNwqUH7lDAuhFKa+NY6EoJ9kZMuOvuu4WwLQ==}
+  '@posthog/browser-common@0.8.2':
+    resolution: {integrity: sha512-8g7+ijrx8bfWmpDjmP07e0ZmdRnJoFqZ6PCcMQvfBTUrr422GRXvQWpQn7yD028zIJHIIn/rUTipKgUC5UkWpw==}
 
-  '@posthog/core@1.50.5':
-    resolution: {integrity: sha512-afEchuShDaVIoxAIj76kDZQ1DhfesDmgfVp+mtTzsA3wlc8DF5uoz8YjuTjnxOicWkpP5HCDqYidK/1kT125Cg==}
+  '@posthog/core@1.52.0':
+    resolution: {integrity: sha512-pvbdeRRpizktmo8MXZQxjAI4aFfNajwkzxbm72wKV9n2wWcnQWa4m+AqTI2zmmCSsYk7F666rRUdvYqZLjjhWg==}
 
-  '@posthog/types@1.409.0':
-    resolution: {integrity: sha512-239umoaZVb2GBaXeEyJpwFvjhrrChJH8NHCwiao23EBSu3NA6EN0MTMoaHSmMEf4yjiXEFFoYJA6FjJAXF5HGA==}
+  '@posthog/types@1.409.4':
+    resolution: {integrity: sha512-X8egIUjMe1uItlxpbLfWypS2SWLOF+5Vzvne/44AsaHa/fYbtSy8itJNk5iQS1MZEwVYAEYUsQY1vuN61jpxTg==}
 
   '@remix-run/router@1.23.4':
     resolution: {integrity: sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==}
@@ -5830,8 +5830,8 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.427.2:
-    resolution: {integrity: sha512-/jRg3ChHuxcHTTJ/xb+IbpXLYxiBKIWdjrsNNqY1tAwjnFoijmz58i4mIR4A2P5MWx+4R7LlpK9vQfBr8v292g==}
+  posthog-js@1.428.10:
+    resolution: {integrity: sha512-QrYzJ1ISRK/aWuio88JIab3XkTy+sFlrF0894jTa1IhEfB3i6KHumxXgePc37aBKTtKBzIpMKqTsPaYDtfl5rQ==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
@@ -8987,16 +8987,16 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@posthog/browser-common@0.7.2':
+  '@posthog/browser-common@0.8.2':
     dependencies:
-      '@posthog/core': 1.50.5
-      '@posthog/types': 1.409.0
+      '@posthog/core': 1.52.0
+      '@posthog/types': 1.409.4
 
-  '@posthog/core@1.50.5':
+  '@posthog/core@1.52.0':
     dependencies:
-      '@posthog/types': 1.409.0
+      '@posthog/types': 1.409.4
 
-  '@posthog/types@1.409.0': {}
+  '@posthog/types@1.409.4': {}
 
   '@remix-run/router@1.23.4': {}
 
@@ -13350,11 +13350,11 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.427.2(@types/react@18.3.31)(react@18.3.1):
+  posthog-js@1.428.10(@types/react@18.3.31)(react@18.3.1):
     dependencies:
-      '@posthog/browser-common': 0.7.2
-      '@posthog/core': 1.50.5
-      '@posthog/types': 1.409.0
+      '@posthog/browser-common': 0.8.2
+      '@posthog/core': 1.52.0
+      '@posthog/types': 1.409.4
       core-js: 3.50.0
       dompurify: 3.4.15
       fflate: 0.4.8


### PR DESCRIPTION
## Weekly dependencies update — 2026-09-09

Automated bundle of all **runtime dependencies** bumped to the latest minor/patch within the same major (the `dependencies` block only).

### Updates

| Package | Old | New | Minor jump | Peer | Security |
|---|---|---|---|---|---|
| `posthog-js` | `1.427.2` | `1.428.10` | +1 |  |  |


### Notes

- Base branch: `main`
- Ranges resolved with `ncu --target minor` at planning time and applied verbatim to the `dependencies` block, then `pnpm install --no-frozen-lockfile`.
- Only `package.json` and `pnpm-lock.yaml` were modified.

🤖 Generated by the `update-deps` skill.

### Changelogs

#### `posthog-js` 1.427.2 → 1.428.10

#### [`posthog-js@1.427.3`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.427.3)

## 1.427.3

### Patch Changes

- [#4815](https://github.com/PostHog/posthog-js/pull/4815) [`c207020`](https://github.com/PostHog/posthog-js/commit/c20702023ed05de61799e4d186b7dd1d040ce251) Thanks [@marandaneto](https://github.com/marandaneto)! - Prevent queued session recording mutations from capturing content beneath DOM or shadow ancestors that have become blocked.
  (2026-09-07)

- [#4785](https://github.com/PostHog/posthog-js/pull/4785) [`74ca945`](https://github.com/PostHog/posthog-js/commit/74ca9458a166b0a5a9f707e74b1a2e6e2852c829) Thanks [@marandaneto](https://github.com/marandaneto)! - Clarify feature flag return-value terminology across SDK APIs. A `false` value is a conclusive off evaluation, while `undefined` means no evaluation is available. Remote evaluation omits globally inactive flags, whereas backend local evaluation can resolve cached inactive definitions to `false`.

- [#4797](https://github.com/PostHog/posthog-js/pull/4797) [`fd4ece8`](https://github.com/PostHog/posthog-js/commit/fd4ece8db1aa313f09724a747e4d450ecdc77da2) Thanks [@posthog](https://github.com/apps/posthog)! - Prevent exception autocapture from throwing when the handler it wraps belongs to another compartment or a destroyed document.

- [#4754](https://github.com/PostHog/posthog-js/pull/4754) [`d73455e`](https://github.com/PostHog/posthog-js/commit/d73455e470822483abbf0e0a20bb3c8fa1bc6e2e) Thanks [@posthog](https://github.com/apps/posthog)! - Session replay now reports why a recording holds its buffer. An epoch that starts without user interaction keeps its snapshots and uploads nothing, while `$recording_status` still reads `active`. Captured events now carry `$sdk_debug_replay_flush_hold_reason` (`no_interaction_since_recording_started` or `no_interaction_since_session_rotated`), and the SDK logs the reason once per held epoch in debug mode. Discarding a recording (for example when the server turns replay off) also no longer uploads the stylesheet mutations the recorder emits as it stops.

- [#4788](https://github.com/PostHog/posthog-js/pull/4788) [`95b159a`](https://github.com/PostHog/posthog-js/commit/95b159a6491c29de87ca0aaf5ea40c787cf0518d) Thanks [@fasyy612](https://github.com/fasyy612)! - fix(replay): reset the idle clock on a session-id rotation so the new session's first snapshot is not dropped as idle and its recording does not start hours early

- [#4770](https://github.com/PostHog/posthog-js/pull/4770) [`24f1937`](https://github.com/PostHog/posthog-js/commit/24f193719a7d87a2b66591c3ab903031bbea62a6) Thanks [@fasyy612](https://github.com/fasyy612)! - fix(replay): drain the compression queue synchronously on a session-id rotation so the old session's unflushed tail ships under the old session id instead of being discarded

- [#4666](https://github.com/PostHog/posthog-js/pull/4666) [`5e74132`](https://github.com/PostHog/posthog-js/commit/5e74132a76a32d5df9c6706dddf1597c748061d2) Thanks [@robbie-c](https://github.com/robbie-c)! - Preserve universally safe JSON-LD properties and allowlisted tree structure when replay redacts other fields. Keep only DOM-backed ID fragments. Keep only `@type` values shaped like a Schema.org term, and limit types and payloads. Publish a reusable sanitization contract fixture.

- [#4814](https://github.com/PostHog/posthog-js/pull/4814) [`21dcebd`](https://github.com/PostHog/posthog-js/commit/21dcebd3361a2fe24b022601b8131ae85a3f077d) Thanks [@posthog](https://github.com/apps/posthog)! - Prevent invalid clock values from breaking UUID generation and continue capturing replay chunks after a chunk fails.
- Updated dependencies [[`74ca945`](https://github.com/PostHog/posthog-js/commit/74ca9458a166b0a5a9f707e74b1a2e6e2852c829), [`5e74132`](https://github.com/PostHog/posthog-js/commit/5e74132a76a32d5df9c6706dddf1597c748061d2), [`21dcebd`](https://github.com/PostHog/posthog-js/commit/21dcebd3361a2fe24b022601b8131ae85a3f077d)]:
  - @posthog/core@1.50.6
  - @posthog/types@1.409.1
  - @posthog/browser-common@0.7.3

---

#### [`posthog-js@1.428.0`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.428.0)

## 1.428.0

### Minor Changes

- [#4809](https://github.com/PostHog/posthog-js/pull/4809) [`3a5b322`](https://github.com/PostHog/posthog-js/commit/3a5b32229a135af56d43a17350a222784d94c88d) Thanks [@marandaneto](https://github.com/marandaneto)! - Add best-effort in-app browser attribution using `$webview_app` and `$webview_app_version`, without changing existing `$browser` or `$browser_version` values. Detect explicit user-agent markers for Facebook, Facebook Lite, Messenger, Instagram, Threads, LinkedIn, Twitter, TikTok, WhatsApp, Snapchat, WeChat, LINE, Google, Bing, Pinterest, Naver, and KakaoTalk. Unknown apps and versions are omitted; missing markers do not imply a standalone browser.
  (2026-09-07)

### Patch Changes

- Updated dependencies [[`3a5b322`](https://github.com/PostHog/posthog-js/commit/3a5b32229a135af56d43a17350a222784d94c88d)]:
  - @posthog/core@1.51.0
  - @posthog/browser-common@0.8.0

---

#### [`posthog-js@1.428.1`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.428.1)

## 1.428.1

### Patch Changes

- [#4804](https://github.com/PostHog/posthog-js/pull/4804) [`988f03a`](https://github.com/PostHog/posthog-js/commit/988f03a75c544eb928904085286446ad39281478) Thanks [@marandaneto](https://github.com/marandaneto)! - Recover autocapture targets for dropdown clicks retargeted to the page root, and attribute nested SVG icon clicks to their enclosing button or link while preserving privacy checks.
  (2026-09-07)
- Updated dependencies [[`988f03a`](https://github.com/PostHog/posthog-js/commit/988f03a75c544eb928904085286446ad39281478)]:
  - @posthog/browser-common@0.8.1

---

#### [`posthog-js@1.428.2`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.428.2)

## 1.428.2

### Patch Changes

- [#4803](https://github.com/PostHog/posthog-js/pull/4803) [`87b34af`](https://github.com/PostHog/posthog-js/commit/87b34af44e46427eba97eaf63aafb82255896a42) Thanks [@marandaneto](https://github.com/marandaneto)! - Preserve Error details, causes, aggregate errors, and custom enumerable properties in event properties, including cross-realm Errors. Apply string truncation to ordinary capture properties and retain custom toJSON serialization for exception additional properties.
  (2026-09-07)
- Updated dependencies [[`87b34af`](https://github.com/PostHog/posthog-js/commit/87b34af44e46427eba97eaf63aafb82255896a42)]:
  - @posthog/browser-common@0.8.2

---

#### [`posthog-js@1.428.3`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.428.3)

## 1.428.3

### Patch Changes

- [#4805](https://github.com/PostHog/posthog-js/pull/4805) [`4cd5717`](https://github.com/PostHog/posthog-js/commit/4cd571766ba341fe64aab058f1132ab5dc0223f5) Thanks [@marandaneto](https://github.com/marandaneto)! - Wait for the initial remote config outcome before using cached autocapture enablement, so a newly disabled project does not capture events while its settings load. Disabled remote requests retain local startup behavior, and failed or incomplete responses retain the cached fallback.
  (2026-09-07)

---

#### [`posthog-js@1.428.4`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.428.4)

## 1.428.4

### Patch Changes

- [#4828](https://github.com/PostHog/posthog-js/pull/4828) [`4ae6405`](https://github.com/PostHog/posthog-js/commit/4ae6405e0c807b0e03bfa5092d7e209eb4671b1c) Thanks [@marandaneto](https://github.com/marandaneto)! - Prevent waking an idle tab from extending the previous session recording across the entire idle gap.
  (2026-09-08)

> 6 newer release(s) not inlined to respect the PR body size limit: [`posthog-js@1.428.5`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.428.5), [`posthog-js@1.428.6`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.428.6), [`posthog-js@1.428.7`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.428.7), [`posthog-js@1.428.8`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.428.8), [`posthog-js@1.428.9`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.428.9), [`posthog-js@1.428.10`](https://github.com/PostHog/posthog-js/releases/tag/posthog-js%401.428.10).

---

