### PR TITLE
chore(deps): remove unused webpack-cli

### DIFF
--- a/carbonio.webpack.ts
+++ b/carbonio.webpack.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+/// <reference types="webpack-dev-server" />
+
 import { execSync } from 'child_process';
 import CopyPlugin from 'copy-webpack-plugin';
 import dotenv from 'dotenv';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import path from 'path';
-import type { Compiler } from 'webpack';
-import type { WebpackConfiguration } from 'webpack-cli';
+import type { Compiler, Configuration } from 'webpack';
 
 dotenv.config();
 
@@ -19,12 +20,12 @@ const commitHash = execSync('git rev-parse HEAD').toString().trim();
 const baseStaticPath = `/static/iris/carbonio-shell-ui/${commitHash}/`;
 
 const configFn = (
-	initialConf: WebpackConfiguration,
+	initialConf: Configuration,
 	pkg: string,
 	options: { host: string; port: number },
 	mode: 'development' | 'production'
-): WebpackConfiguration => {
-	const conf: WebpackConfiguration = { ...initialConf };
+): Configuration => {
+	const conf: Configuration = { ...initialConf };
 	const server = `https://${options.host}`;
 	const root = 'carbonio';
 	conf.entry = {
@@ -112,7 +113,7 @@ const configFn = (
 		]
 	};
 	conf.externals = {};
-	const rules: NonNullable<WebpackConfiguration['module']>['rules'] = conf.module?.rules ?? [];
+	const rules: NonNullable<Configuration['module']>['rules'] = conf.module?.rules ?? [];
 	rules.push({
 		test: /\.(woff(2)?|ttf|eot)$/,
 		type: 'asset/resource',

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
 		"vitest": "4.1.10",
 		"vitest-fail-on-console": "0.10.1",
 		"webpack": "5.110.3",
-		"webpack-cli": "6.0.1",
 		"webpack-dev-server": "5.2.6"
 	},
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,7 +153,7 @@ importers:
         version: 18.3.7(@types/react@18.3.31)
       '@types/webpack':
         specifier: 5.28.5
-        version: 5.28.5(postcss@8.5.15)(webpack-cli@6.0.1)
+        version: 5.28.5(postcss@8.5.15)
       '@types/webpack-env':
         specifier: 1.18.8
         version: 1.18.8
@@ -165,19 +165,19 @@ importers:
         version: 2.1.0(@testing-library/dom@10.4.1)(@types/eslint@9.6.1)(typescript@5.9.3)
       '@zextras/carbonio-ui-sdk':
         specifier: 2.3.12
-        version: 2.3.12(tslib@2.8.1)(typescript@5.9.3)(webpack-cli@6.0.1)
+        version: 2.3.12(tslib@2.8.1)(typescript@5.9.3)
       autoprefixer:
         specifier: 10.5.5
         version: 10.5.5(postcss@8.5.15)
       copy-webpack-plugin:
         specifier: 14.0.0
-        version: 14.0.0(webpack@5.110.3)
+        version: 14.0.0(webpack@5.110.3(postcss@8.5.15))
       core-js:
         specifier: 3.50.0
         version: 3.50.0
       css-loader:
         specifier: 6.11.0
-        version: 6.11.0(webpack@5.110.3)
+        version: 6.11.0(webpack@5.110.3(postcss@8.5.15))
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
@@ -189,7 +189,7 @@ importers:
         version: 1.0.0(eslint@8.57.1)
       html-webpack-plugin:
         specifier: 5.6.8
-        version: 5.6.8(webpack@5.110.3)
+        version: 5.6.8(webpack@5.110.3(postcss@8.5.15))
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -204,13 +204,13 @@ importers:
         version: 29.1.1
       mini-css-extract-plugin:
         specifier: 2.10.2
-        version: 2.10.2(webpack@5.110.3)
+        version: 2.10.2(webpack@5.110.3(postcss@8.5.15))
       msw:
         specifier: 2.15.0
         version: 2.15.0(@types/node@22.20.1)(typescript@5.9.3)
       postcss-loader:
         specifier: 8.2.1
-        version: 8.2.1(postcss@8.5.15)(typescript@5.9.3)(webpack@5.110.3)
+        version: 8.2.1(postcss@8.5.15)(typescript@5.9.3)(webpack@5.110.3(postcss@8.5.15))
       semantic-release:
         specifier: 25.0.9
         version: 25.0.9(typescript@5.9.3)
@@ -228,13 +228,10 @@ importers:
         version: 0.10.1(@vitest/utils@4.1.10)(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2))(vitest@4.1.10)
       webpack:
         specifier: 5.110.3
-        version: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
-      webpack-cli:
-        specifier: 6.0.1
-        version: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.110.3)
+        version: 5.110.3(postcss@8.5.15)
       webpack-dev-server:
         specifier: 5.2.6
-        version: 5.2.6(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.110.3)
+        version: 5.2.6(tslib@2.8.1)(webpack@5.110.3(postcss@8.5.15))
 
 packages:
 
@@ -965,10 +962,6 @@ packages:
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
-
-  '@discoveryjs/json-ext@0.6.3':
-    resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
-    engines: {node: '>=14.17.0'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -2601,31 +2594,6 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@webpack-cli/configtest@3.0.1':
-    resolution: {integrity: sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      webpack: ^5.82.0
-      webpack-cli: 6.x.x
-
-  '@webpack-cli/info@3.0.1':
-    resolution: {integrity: sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      webpack: ^5.82.0
-      webpack-cli: 6.x.x
-
-  '@webpack-cli/serve@3.0.1':
-    resolution: {integrity: sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      webpack: ^5.82.0
-      webpack-cli: 6.x.x
-      webpack-dev-server: '*'
-    peerDependenciesMeta:
-      webpack-dev-server:
-        optional: true
-
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -3179,10 +3147,6 @@ packages:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
 
-  clone-deep@4.0.1:
-    resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
-    engines: {node: '>=6'}
-
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -3210,10 +3174,6 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-
-  commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -3732,11 +3692,6 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
-  envinfo@7.21.0:
-    resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -4082,10 +4037,6 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
-  fastest-levenshtein@1.0.16:
-    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
-    engines: {node: '>= 4.9.1'}
-
   fastparse@1.1.2:
     resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
 
@@ -4143,10 +4094,6 @@ packages:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
     engines: {node: '>=4'}
 
-  find-up@4.1.0:
-    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
-    engines: {node: '>=8'}
-
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -4162,10 +4109,6 @@ packages:
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
-
-  flat@5.0.2:
-    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
-    hasBin: true
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
@@ -4557,11 +4500,6 @@ packages:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
 
-  import-local@3.2.0:
-    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
-    engines: {node: '>=8'}
-    hasBin: true
-
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
@@ -4598,10 +4536,6 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
-
-  interpret@3.1.1:
-    resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
-    engines: {node: '>=10.13.0'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -4730,10 +4664,6 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  is-plain-object@2.0.4:
-    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
-    engines: {node: '>=0.10.0'}
-
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
@@ -4801,10 +4731,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isobject@3.0.1:
-    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
-    engines: {node: '>=0.10.0'}
 
   issue-parser@7.0.2:
     resolution: {integrity: sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==}
@@ -4910,10 +4836,6 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  kind-of@6.0.3:
-    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
-    engines: {node: '>=0.10.0'}
-
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
 
@@ -4968,10 +4890,6 @@ packages:
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
-
-  locate-path@5.0.0:
-    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
-    engines: {node: '>=8'}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -5594,10 +5512,6 @@ packages:
     resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
     engines: {node: '>=4'}
 
-  p-limit@2.3.0:
-    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
-    engines: {node: '>=6'}
-
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -5609,10 +5523,6 @@ packages:
   p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
-
-  p-locate@4.1.0:
-    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
-    engines: {node: '>=8'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -5641,10 +5551,6 @@ packages:
   p-try@1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
     engines: {node: '>=4'}
-
-  p-try@2.2.0:
-    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
-    engines: {node: '>=6'}
 
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
@@ -5757,10 +5663,6 @@ packages:
   pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
-
-  pkg-dir@4.2.0:
-    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
-    engines: {node: '>=8'}
 
   pkg-dir@7.0.0:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
@@ -6053,10 +5955,6 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  rechoir@0.8.0:
-    resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
-    engines: {node: '>= 10.13.0'}
-
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -6118,10 +6016,6 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
-
-  resolve-cwd@3.0.0:
-    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
-    engines: {node: '>=8'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -6282,10 +6176,6 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-
-  shallow-clone@3.0.1:
-    resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
-    engines: {node: '>=8'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -7026,20 +6916,6 @@ packages:
     engines: {node: '>= 10.13.0'}
     hasBin: true
 
-  webpack-cli@6.0.1:
-    resolution: {integrity: sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==}
-    engines: {node: '>=18.12.0'}
-    hasBin: true
-    peerDependencies:
-      webpack: ^5.82.0
-      webpack-bundle-analyzer: '*'
-      webpack-dev-server: '*'
-    peerDependenciesMeta:
-      webpack-bundle-analyzer:
-        optional: true
-      webpack-dev-server:
-        optional: true
-
   webpack-dev-middleware@7.4.5:
     resolution: {integrity: sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==}
     engines: {node: '>= 18.12.0'}
@@ -7074,10 +6950,6 @@ packages:
         optional: true
       webpack-cli:
         optional: true
-
-  webpack-merge@6.0.1:
-    resolution: {integrity: sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==}
-    engines: {node: '>=18.0.0'}
 
   webpack-sources@3.5.0:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
@@ -7156,9 +7028,6 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  wildcard@2.0.1:
-    resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -8243,8 +8112,6 @@ snapshots:
   '@csstools/css-tokenizer@4.0.0': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
-
-  '@discoveryjs/json-ext@0.6.3': {}
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -9576,11 +9443,11 @@ snapshots:
 
   '@types/webpack-env@1.18.8': {}
 
-  '@types/webpack@5.28.5(postcss@8.5.15)(webpack-cli@6.0.1)':
+  '@types/webpack@5.28.5(postcss@8.5.15)':
     dependencies:
       '@types/node': 22.20.1
       tapable: 2.3.3
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
+      webpack: 5.110.3(postcss@8.5.15)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@napi-rs/image'
@@ -9988,23 +9855,6 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.110.3)':
-    dependencies:
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.110.3)
-
-  '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.110.3)':
-    dependencies:
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.110.3)
-
-  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.6)(webpack@5.110.3)':
-    dependencies:
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.110.3)
-    optionalDependencies:
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.110.3)
-
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -10064,28 +9914,28 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@zextras/carbonio-ui-sdk@2.3.12(tslib@2.8.1)(typescript@5.9.3)(webpack-cli@6.0.1)':
+  '@zextras/carbonio-ui-sdk@2.3.12(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.29.6
       '@svgr/webpack': 5.5.0
-      babel-loader: 9.2.1(@babel/core@7.29.6)(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1))
-      circular-dependency-plugin: 5.2.2(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1))
-      copy-webpack-plugin: 13.0.1(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1))
-      css-loader: 6.11.0(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1))
+      babel-loader: 9.2.1(@babel/core@7.29.6)(webpack@5.108.3(postcss@8.5.10))
+      circular-dependency-plugin: 5.2.2(webpack@5.108.3(postcss@8.5.10))
+      copy-webpack-plugin: 13.0.1(webpack@5.108.3(postcss@8.5.10))
+      css-loader: 6.11.0(webpack@5.108.3(postcss@8.5.10))
       handlebars: 4.7.9
       handlebars-loader: 1.7.3(handlebars@4.7.9)
-      html-webpack-plugin: 5.6.7(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1))
+      html-webpack-plugin: 5.6.7(webpack@5.108.3(postcss@8.5.10))
       less: 4.6.7
-      less-loader: 12.3.3(less@4.6.7)(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1))
-      mini-css-extract-plugin: 2.10.2(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1))
+      less-loader: 12.3.3(less@4.6.7)(webpack@5.108.3(postcss@8.5.10))
+      mini-css-extract-plugin: 2.10.2(webpack@5.108.3(postcss@8.5.10))
       node-http-proxy-json: 0.1.9
       path-browserify: 1.0.1
       postcss: 8.5.10
-      postcss-loader: 8.2.1(postcss@8.5.10)(typescript@5.9.3)(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1))
+      postcss-loader: 8.2.1(postcss@8.5.10)(typescript@5.9.3)(webpack@5.108.3(postcss@8.5.10))
       semver: 7.8.5
-      webpack: 5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.3(postcss@8.5.10)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1))
+      webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.10))
       yargs: 18.0.0
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -10363,12 +10213,12 @@ snapshots:
 
   b4a@1.8.1: {}
 
-  babel-loader@9.2.1(@babel/core@7.29.6)(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)):
+  babel-loader@9.2.1(@babel/core@7.29.6)(webpack@5.108.3(postcss@8.5.10)):
     dependencies:
       '@babel/core': 7.29.6
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.3(postcss@8.5.10)
 
   babel-plugin-macros@3.1.0:
     dependencies:
@@ -10607,9 +10457,9 @@ snapshots:
 
   ci-info@4.4.0: {}
 
-  circular-dependency-plugin@5.2.2(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)):
+  circular-dependency-plugin@5.2.2(webpack@5.108.3(postcss@8.5.10)):
     dependencies:
-      webpack: 5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.3(postcss@8.5.10)
 
   clean-css@5.3.3:
     dependencies:
@@ -10654,12 +10504,6 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
-  clone-deep@4.0.1:
-    dependencies:
-      is-plain-object: 2.0.4
-      kind-of: 6.0.3
-      shallow-clone: 3.0.1
-
   clsx@2.1.1: {}
 
   coa@2.0.2:
@@ -10685,8 +10529,6 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-
-  commander@12.1.0: {}
 
   commander@14.0.3: {}
 
@@ -10795,23 +10637,23 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)):
+  copy-webpack-plugin@13.0.1(webpack@5.108.3(postcss@8.5.10)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       tinyglobby: 0.2.17
-      webpack: 5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.3(postcss@8.5.10)
 
-  copy-webpack-plugin@14.0.0(webpack@5.110.3):
+  copy-webpack-plugin@14.0.0(webpack@5.110.3(postcss@8.5.15)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 7.1.1
       tinyglobby: 0.2.17
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
+      webpack: 5.110.3(postcss@8.5.15)
 
   core-js-compat@3.49.0:
     dependencies:
@@ -10872,7 +10714,7 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
-  css-loader@6.11.0(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)):
+  css-loader@6.11.0(webpack@5.108.3(postcss@8.5.10)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -10883,9 +10725,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.3(postcss@8.5.10)
 
-  css-loader@6.11.0(webpack@5.110.3):
+  css-loader@6.11.0(webpack@5.110.3(postcss@8.5.15)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -10896,7 +10738,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
+      webpack: 5.110.3(postcss@8.5.15)
 
   css-select-base-adapter@0.1.1: {}
 
@@ -11209,8 +11051,6 @@ snapshots:
       java-properties: 1.0.2
 
   env-paths@2.2.1: {}
-
-  envinfo@7.21.0: {}
 
   environment@1.1.0: {}
 
@@ -11761,8 +11601,6 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
-  fastest-levenshtein@1.0.16: {}
-
   fastparse@1.1.2: {}
 
   fastq@1.20.1:
@@ -11820,11 +11658,6 @@ snapshots:
     dependencies:
       locate-path: 2.0.0
 
-  find-up@4.1.0:
-    dependencies:
-      locate-path: 5.0.0
-      path-exists: 4.0.0
-
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -11845,8 +11678,6 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
       rimraf: 3.0.2
-
-  flat@5.0.2: {}
 
   flatted@3.4.2: {}
 
@@ -12113,7 +11944,7 @@ snapshots:
     dependencies:
       void-elements: 3.1.0
 
-  html-webpack-plugin@5.6.7(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)):
+  html-webpack-plugin@5.6.7(webpack@5.108.3(postcss@8.5.10)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -12121,9 +11952,9 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.3(postcss@8.5.10)
 
-  html-webpack-plugin@5.6.8(webpack@5.110.3):
+  html-webpack-plugin@5.6.8(webpack@5.110.3(postcss@8.5.15)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -12131,7 +11962,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
+      webpack: 5.110.3(postcss@8.5.15)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -12265,11 +12096,6 @@ snapshots:
 
   import-lazy@4.0.0: {}
 
-  import-local@3.2.0:
-    dependencies:
-      pkg-dir: 4.2.0
-      resolve-cwd: 3.0.0
-
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
@@ -12296,8 +12122,6 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
-
-  interpret@3.1.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -12410,10 +12234,6 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-plain-object@2.0.4:
-    dependencies:
-      isobject: 3.0.1
-
   is-potential-custom-element-name@1.0.1: {}
 
   is-regex@1.2.1:
@@ -12472,8 +12292,6 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
-
-  isobject@3.0.1: {}
 
   issue-parser@7.0.2:
     dependencies:
@@ -12595,8 +12413,6 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  kind-of@6.0.3: {}
-
   language-subtag-registry@0.3.23: {}
 
   language-tags@1.0.9:
@@ -12608,11 +12424,11 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.4
 
-  less-loader@12.3.3(less@4.6.7)(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)):
+  less-loader@12.3.3(less@4.6.7)(webpack@5.108.3(postcss@8.5.10)):
     dependencies:
       less: 4.6.7
     optionalDependencies:
-      webpack: 5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.3(postcss@8.5.10)
 
   less@4.6.7:
     dependencies:
@@ -12659,10 +12475,6 @@ snapshots:
     dependencies:
       p-locate: 2.0.0
       path-exists: 3.0.0
-
-  locate-path@5.0.0:
-    dependencies:
-      p-locate: 4.1.0
 
   locate-path@6.0.0:
     dependencies:
@@ -12829,17 +12641,17 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)):
+  mini-css-extract-plugin@2.10.2(webpack@5.108.3(postcss@8.5.10)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.3(postcss@8.5.10)
 
-  mini-css-extract-plugin@2.10.2(webpack@5.110.3):
+  mini-css-extract-plugin@2.10.2(webpack@5.110.3(postcss@8.5.15)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
+      webpack: 5.110.3(postcss@8.5.15)
 
   minimalistic-assert@1.0.1: {}
 
@@ -12861,23 +12673,23 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.10.0(postcss@8.5.15)(webpack@5.110.3):
+  minimizer-webpack-plugin@5.10.0(postcss@8.5.15)(webpack@5.110.3(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.51.2
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
+      webpack: 5.110.3(postcss@8.5.15)
     optionalDependencies:
       postcss: 8.5.15
 
-  minimizer-webpack-plugin@5.6.1(postcss@8.5.10)(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)):
+  minimizer-webpack-plugin@5.6.1(postcss@8.5.10)(webpack@5.108.3(postcss@8.5.10)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.3(postcss@8.5.10)
     optionalDependencies:
       postcss: 8.5.10
 
@@ -13130,10 +12942,6 @@ snapshots:
     dependencies:
       p-try: 1.0.0
 
-  p-limit@2.3.0:
-    dependencies:
-      p-try: 2.2.0
-
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -13145,10 +12953,6 @@ snapshots:
   p-locate@2.0.0:
     dependencies:
       p-limit: 1.3.0
-
-  p-locate@4.1.0:
-    dependencies:
-      p-limit: 2.3.0
 
   p-locate@5.0.0:
     dependencies:
@@ -13171,8 +12975,6 @@ snapshots:
   p-timeout@6.1.4: {}
 
   p-try@1.0.0: {}
-
-  p-try@2.2.0: {}
 
   param-case@3.0.4:
     dependencies:
@@ -13265,10 +13067,6 @@ snapshots:
       find-up: 2.1.0
       load-json-file: 4.0.0
 
-  pkg-dir@4.2.0:
-    dependencies:
-      find-up: 4.1.0
-
   pkg-dir@7.0.0:
     dependencies:
       find-up: 6.3.0
@@ -13288,25 +13086,25 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-loader@8.2.1(postcss@8.5.10)(typescript@5.9.3)(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)):
+  postcss-loader@8.2.1(postcss@8.5.10)(typescript@5.9.3)(webpack@5.108.3(postcss@8.5.10)):
     dependencies:
       cosmiconfig: 9.0.2(typescript@5.9.3)
       jiti: 2.7.0
       postcss: 8.5.10
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.3(postcss@8.5.10)
     transitivePeerDependencies:
       - typescript
 
-  postcss-loader@8.2.1(postcss@8.5.15)(typescript@5.9.3)(webpack@5.110.3):
+  postcss-loader@8.2.1(postcss@8.5.15)(typescript@5.9.3)(webpack@5.110.3(postcss@8.5.15)):
     dependencies:
       cosmiconfig: 9.0.2(typescript@5.9.3)
       jiti: 2.7.0
       postcss: 8.5.15
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
+      webpack: 5.110.3(postcss@8.5.15)
     transitivePeerDependencies:
       - typescript
 
@@ -13588,10 +13386,6 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
-  rechoir@0.8.0:
-    dependencies:
-      resolve: 1.22.12
-
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -13663,10 +13457,6 @@ snapshots:
   requireindex@1.2.0: {}
 
   requires-port@1.0.0: {}
-
-  resolve-cwd@3.0.0:
-    dependencies:
-      resolve-from: 5.0.0
 
   resolve-from@4.0.0: {}
 
@@ -13903,10 +13693,6 @@ snapshots:
       es-object-atoms: 1.1.2
 
   setprototypeof@1.2.0: {}
-
-  shallow-clone@3.0.1:
-    dependencies:
-      kind-of: 6.0.3
 
   shebang-command@2.0.0:
     dependencies:
@@ -14691,26 +14477,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-cli@6.0.1(webpack-dev-server@5.2.6)(webpack@5.110.3):
-    dependencies:
-      '@discoveryjs/json-ext': 0.6.3
-      '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1)(webpack@5.110.3)
-      '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1)(webpack@5.110.3)
-      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.6)(webpack@5.110.3)
-      colorette: 2.0.20
-      commander: 12.1.0
-      cross-spawn: 7.0.6
-      envinfo: 7.21.0
-      fastest-levenshtein: 1.0.16
-      import-local: 3.2.0
-      interpret: 3.1.1
-      rechoir: 0.8.0
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
-      webpack-merge: 6.0.1
-    optionalDependencies:
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.110.3)
-
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.10)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.8(tslib@2.8.1)
@@ -14719,11 +14486,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)
+      webpack: 5.108.3(postcss@8.5.10)
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.110.3):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.110.3(postcss@8.5.15)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.8(tslib@2.8.1)
@@ -14732,11 +14499,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
+      webpack: 5.110.3(postcss@8.5.15)
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.5(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)):
+  webpack-dev-server@5.2.5(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.10)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -14764,11 +14531,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.3(postcss@8.5.10))
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.108.3(postcss@8.5.10)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.110.3)
+      webpack: 5.108.3(postcss@8.5.10)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -14776,7 +14542,7 @@ snapshots:
       - tslib
       - utf-8-validate
 
-  webpack-dev-server@5.2.6(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.110.3):
+  webpack-dev-server@5.2.6(tslib@2.8.1)(webpack@5.110.3(postcss@8.5.15)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -14804,29 +14570,22 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.110.3)
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.110.3(postcss@8.5.15))
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.110.3)
+      webpack: 5.110.3(postcss@8.5.15)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - tslib
       - utf-8-validate
-
-  webpack-merge@6.0.1:
-    dependencies:
-      clone-deep: 4.0.1
-      flat: 5.0.2
-      wildcard: 2.0.1
 
   webpack-sources@3.5.0: {}
 
   webpack-sources@3.5.1: {}
 
-  webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1):
+  webpack@5.108.3(postcss@8.5.10):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -14844,14 +14603,12 @@ snapshots:
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(postcss@8.5.10)(webpack@5.108.3(postcss@8.5.10)(webpack-cli@6.0.1))
+      minimizer-webpack-plugin: 5.6.1(postcss@8.5.10)(webpack@5.108.3(postcss@8.5.10))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
       watchpack: 2.5.2
       webpack-sources: 3.5.0
-    optionalDependencies:
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.110.3)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -14866,7 +14623,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.110.3(postcss@8.5.15)(webpack-cli@6.0.1):
+  webpack@5.110.3(postcss@8.5.15):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -14881,14 +14638,12 @@ snapshots:
       events: 3.3.0
       graceful-fs: 4.2.11
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.10.0(postcss@8.5.15)(webpack@5.110.3)
+      minimizer-webpack-plugin: 5.10.0(postcss@8.5.15)(webpack@5.110.3(postcss@8.5.15))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
       watchpack: 2.5.2
       webpack-sources: 3.5.1
-    optionalDependencies:
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.6)(webpack@5.110.3)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@napi-rs/image'
@@ -14981,8 +14736,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wildcard@2.0.1: {}
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## What

Removes `webpack-cli` from `devDependencies`. It is not used by anything.

| Package | Before | After |
|---|---|---|
| `webpack-cli` | `6.0.1` | *removed* |

## Why it was there, and why it no longer needs to be

The only reference to it in the whole repository was a type import in `carbonio.webpack.ts`:

```ts
import type { WebpackConfiguration } from 'webpack-cli';
```

And `WebpackConfiguration` was a plain alias of webpack's own type:

```ts
// webpack-cli@6 lib/types.d.ts
type WebpackConfiguration = Configuration;
```

webpack-cli 7 stopped shipping `lib/types.d.ts` altogether, so that import has no future either way. The build config now uses `Configuration` from `webpack` directly, which removes the last reason to depend on webpack-cli at all.

## Evidence that nothing invokes the CLI

| Check | Result |
|---|---|
| `@zextras/carbonio-ui-sdk` (`sdk build` / `sdk watch`) | Drives webpack programmatically — `require("webpack")` and `require("webpack-dev-server")`. Zero occurrences of `webpack-cli` anywhere in its `dist/` |
| Package scripts | None runs `webpack` or `webpack serve`; build and watch both go through `sdk` |
| `webpack` and `webpack-dev-server` | Both declare `peerDependenciesMeta.webpack-cli.optional: true` — it was never a required peer |

## The `devServer` subtlety

`conf.devServer` is **not** part of webpack's `Configuration`. It is added by a module augmentation that lives in webpack-dev-server:

```ts
// webpack-dev-server/types/lib/Server.d.ts
declare module "webpack" {
  interface Configuration {
    devServer?: DevServerConfiguration | undefined;
  }
}
```

webpack-cli's type declarations imported webpack-dev-server, which pulled that augmentation into the program as a side effect. Without webpack-cli the augmentation has to be requested explicitly:

```ts
/// <reference types="webpack-dev-server" />
```

Otherwise `tsc --project tsconfig.build.json` fails with `TS2339: Property 'devServer' does not exist on type 'Configuration'`. This is why the diff touches `carbonio.webpack.ts` and not just `package.json`.

## Verification

All run locally on this branch, with `webpack-cli` absent from `node_modules`:

| Check | Result |
|---|---|
| `pnpm type-check` (src) | ✅ clean |
| `tsc --project tsconfig.build.json --noEmit` (build config) | ✅ clean |
| `pnpm lint` | ✅ 0 errors (5 pre-existing `sonarjs/cognitive-complexity` warnings) |
| `prettier --check carbonio.webpack.ts` | ✅ clean |
| `pnpm build:pkg` (`sdk build` → webpack) | ✅ compiled successfully |
| `pnpm build:lib` (api-extractor) | ✅ API report up to date |
| `pnpm test` | ✅ 39 files, 688 tests passed |

`sdk watch` was not exercised (it needs a host and credentials), but it reaches webpack-dev-server through the same programmatic `require` as `sdk build`.

Side effect: the lockfile loses ~320 lines, since the `@webpack-cli/*` subpackages and the `(webpack-cli@6.0.1)` peer suffixes go away.

## Note on the branch name

The branch is still called `chore/webpack-cli-7` — it started out as a bump to webpack-cli 7.2.3 before it became clear the dependency could simply go. GitHub does not allow retargeting an open PR's head branch, so the name stays; the content is the removal.

## Note on `sonarqube-scanner`

Originally this was planned as a two-package PR together with `sonarqube-scanner` 4.3.8 → 5.0.0, which has been **left out on purpose**. Version 5 removes the `sonar` and `sonar-scanner` executable aliases and only ships `sonar-scanner-npm`, while the shared pipeline still calls the old name:

```groovy
// jenkins-lib-common@v4.10.7 — vars/uiPipeline.groovy:260
npx sonar-scanner -Dsonar.projectKey=${sonarProjectKey} ...
```

Bumping it would break the SonarQube analysis stage, and silently: `npx sonar-scanner` would fall back to downloading the unrelated, abandoned `sonar-scanner` package (last published 2022) rather than failing outright. It needs a coordinated migration across the UI projects — every project to `4.4.0` first (it ships `sonar-scanner-npm` **alongside** the old aliases), then the shared library switches to the new executable name, then 5.x. `carbonio-admin-console-ui` and `carbonio-admin-login-ui` already resolve `4.4.0` through their `^4.3.8` range, so the second step can be validated there first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
