### PR TITLE
chore(deps): remove unused @types/webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
 		"@types/node": "22.20.1",
 		"@types/react": "18.3.31",
 		"@types/react-dom": "18.3.7",
-		"@types/webpack": "5.28.5",
 		"@types/webpack-env": "1.18.8",
 		"@vitest/coverage-istanbul": "4.1.10",
 		"@zextras/carbonio-ui-configs": "2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,9 +151,6 @@ importers:
       '@types/react-dom':
         specifier: 18.3.7
         version: 18.3.7(@types/react@18.3.31)
-      '@types/webpack':
-        specifier: 5.28.5
-        version: 5.28.5(postcss@8.5.15)(webpack-cli@6.0.1)
       '@types/webpack-env':
         specifier: 1.18.8
         version: 1.18.8
@@ -2270,9 +2267,6 @@ packages:
 
   '@types/webpack-env@1.18.8':
     resolution: {integrity: sha512-G9eAoJRMLjcvN4I08wB5I7YofOb/kaJNd5uoCMX+LbKXTPCF+ZIHuqTnFaK9Jz1rgs035f9JUPUhNFtqgucy/A==}
-
-  '@types/webpack@5.28.5':
-    resolution: {integrity: sha512-wR87cgvxj3p6D0Crt1r5avwqffqPXUkNlnQ1mjU93G7gCuFjufZR4I6j8cz5g1F1tTYpfOOFvly+cmIQwL9wvw==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -9575,30 +9569,6 @@ snapshots:
   '@types/ua-parser-js@0.7.39': {}
 
   '@types/webpack-env@1.18.8': {}
-
-  '@types/webpack@5.28.5(postcss@8.5.15)(webpack-cli@6.0.1)':
-    dependencies:
-      '@types/node': 22.20.1
-      tapable: 2.3.3
-      webpack: 5.110.3(postcss@8.5.15)(webpack-cli@6.0.1)
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@napi-rs/image'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - imagemin
-      - lightningcss
-      - postcss
-      - sharp
-      - svgo
-      - uglify-js
-      - webpack-cli
 
   '@types/ws@8.18.1':
     dependencies:


### PR DESCRIPTION
## What

Removes `@types/webpack` from `devDependencies`. No code changes — `package.json` and the lockfile only.

| Package | Before | After |
|---|---|---|
| `@types/webpack` | `5.28.5` | *removed* |

## Why

The installed package is, in its entirety, a re-export of webpack's own types:

```ts
// node_modules/@types/webpack/index.d.ts
/// <reference types="node" />
import webpack = require("webpack");
export = webpack;
```

It is a leftover from the webpack 4 era, when webpack shipped no type declarations of its own. webpack 5 does, so the stub adds nothing. It is not formally deprecated on npm — it still lists `webpack: ^5` as a dependency — but there is nothing in it to use.

## Why nothing needs it

| Check | Result |
|---|---|
| `pnpm why @types/webpack` | One consumer only: this package's own `devDependencies`. Nothing in the tree pulls it in |
| `tsconfig.json` (used by `pnpm type-check`) | `types: ["vitest/globals", "webpack-env", "webpack-dev-server"]` — no `webpack` |
| `tsconfig.lib.json` | Explicit `types` list, no `webpack` |
| `tsconfig.build.json` | Picks it up only because it declares no `types` and so takes everything under `@types/`. `carbonio.webpack.ts` imports from `'webpack'` regardless, which resolves to webpack's own declarations |

## Not to be confused with `@types/webpack-env`

That one **stays**: `src/index.tsx:44-45` uses `module.hot` / `module.hot.accept()`, and it is already declared as `"webpack-env"` in `tsconfig.json`'s `types`.

## Verification

All run locally on this branch, with `@types/webpack` absent from `node_modules`:

| Check | Result |
|---|---|
| `pnpm type-check` (src) | ✅ clean |
| `tsc --project tsconfig.build.json --noEmit` (build config) | ✅ clean |
| `pnpm lint` | ✅ 0 errors (5 pre-existing `sonarjs/cognitive-complexity` warnings) |
| `pnpm build:pkg` (`sdk build` → webpack) | ✅ compiled successfully |
| `pnpm build:lib` (api-extractor) | ✅ API report up to date |
| `pnpm test` | ✅ 39 files, 688 tests passed |

`webpack` itself stays resolved at `5.110.3`, being a direct dev dependency.

## Relation to #903

Independent of #903 (`chore(deps): remove unused webpack-cli`) and mergeable in either order — this branch is cut from `main` and needs no source change, since webpack-cli 6 still provides its own types there.

The one caveat: both PRs touch `pnpm-lock.yaml`, so whichever merges second will need its lockfile refreshed against the new `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
