### PR TITLE
chore(deps): update jsdom to 30.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 		"husky": "9.1.7",
 		"identity-obj-proxy": "3.0.0",
 		"is-ci": "4.1.0",
-		"jsdom": "29.1.1",
+		"jsdom": "30.0.1",
 		"mini-css-extract-plugin": "2.10.2",
 		"msw": "2.15.0",
 		"postcss-loader": "8.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,8 +200,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       jsdom:
-        specifier: 29.1.1
-        version: 29.1.1
+        specifier: 30.0.1
+        version: 30.0.1
       mini-css-extract-plugin:
         specifier: 2.10.2
         version: 2.10.2(webpack@5.110.3)
@@ -222,7 +222,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-istanbul@4.1.10)(jsdom@29.1.1)(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.1)(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2))
       vitest-fail-on-console:
         specifier: 0.10.1
         version: 0.10.1(@vitest/utils@4.1.10)(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2))(vitest@4.1.10)
@@ -253,20 +253,13 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
-  '@asamuzakjp/css-color@5.1.11':
-    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
-  '@asamuzakjp/dom-selector@7.1.1':
-    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  '@asamuzakjp/generational-cache@1.0.1':
-    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  '@asamuzakjp/nwsapi@2.3.9':
-    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -926,19 +919,19 @@ packages:
     resolution: {integrity: sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==}
     engines: {node: '>=22'}
 
-  '@csstools/color-helpers@6.0.2':
-    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
     engines: {node: '>=20.19.0'}
 
-  '@csstools/css-calc@3.2.1':
-    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-color-parser@4.1.8':
-    resolution: {integrity: sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==}
+  '@csstools/css-color-parser@4.2.2':
+    resolution: {integrity: sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -950,8 +943,8 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.5':
-    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+  '@csstools/css-syntax-patches-for-csstree@1.1.12':
+    resolution: {integrity: sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==}
     peerDependencies:
       css-tree: ^3.2.1
     peerDependenciesMeta:
@@ -4856,11 +4849,11 @@ packages:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
-  jsdom@29.1.1:
-    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
     peerDependencies:
-      canvas: ^3.0.0
+      canvas: ^3.2.3
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -5027,6 +5020,10 @@ packages:
 
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -6668,6 +6665,10 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -6795,6 +6796,10 @@ packages:
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.10.2:
+    resolution: {integrity: sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==}
+    engines: {node: '>=22.19.0'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -7123,6 +7128,10 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  whatwg-url@17.1.1:
+    resolution: {integrity: sha512-ohjk1mdUebJVadRt3bAhQhx8lSnISq+GDttK79LFl8EHQkAPvzwctoasC4hs8tBt6kLAncBWWyq1N52qEfKvDw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -7302,25 +7311,20 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
-  '@asamuzakjp/css-color@5.1.11':
+  '@asamuzakjp/css-color@6.0.7':
     dependencies:
-      '@asamuzakjp/generational-cache': 1.0.1
-      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.1.8(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
 
-  '@asamuzakjp/dom-selector@7.1.1':
+  '@asamuzakjp/dom-selector@8.3.2':
     dependencies:
-      '@asamuzakjp/generational-cache': 1.0.1
-      '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-
-  '@asamuzakjp/generational-cache@1.0.1': {}
-
-  '@asamuzakjp/nwsapi@2.3.9': {}
+      lru-cache: 11.5.2
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -8218,17 +8222,17 @@ snapshots:
 
   '@conventional-changelog/template@1.4.0': {}
 
-  '@csstools/color-helpers@6.0.2': {}
+  '@csstools/color-helpers@6.1.1': {}
 
-  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-color-parser@4.1.8(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-color-parser@4.2.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/color-helpers': 6.0.2
-      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
@@ -8236,7 +8240,7 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+  '@csstools/css-syntax-patches-for-csstree@1.1.12(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
 
@@ -9421,7 +9425,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
     optionalDependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-istanbul@4.1.10)(jsdom@29.1.1)(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.1)(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2))
 
   '@testing-library/react@16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9866,7 +9870,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-istanbul@4.1.10)(jsdom@29.1.1)(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.1)(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -12530,28 +12534,28 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@29.1.1:
+  jsdom@30.0.1:
     dependencies:
-      '@asamuzakjp/css-color': 5.1.11
-      '@asamuzakjp/dom-selector': 7.1.1
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
       '@bramus/specificity': 2.4.2
-      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.12(css-tree@3.2.1)
       '@exodus/bytes': 1.15.1
       css-tree: 3.2.1
       data-urls: 7.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.5.1
+      lru-cache: 11.5.2
       parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 6.0.1
-      undici: 7.28.0
+      tough-cookie: 6.0.2
+      undici: 8.10.2
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 17.1.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -12708,6 +12712,8 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.1: {}
+
+  lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -14358,6 +14364,10 @@ snapshots:
     dependencies:
       tldts: 7.4.3
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.3
+
   tr46@0.0.3: {}
 
   tr46@6.0.0:
@@ -14475,6 +14485,8 @@ snapshots:
   undici@6.27.0: {}
 
   undici@7.28.0: {}
+
+  undici@8.10.2: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -14602,9 +14614,9 @@ snapshots:
       '@vitest/utils': 4.1.10
       chalk: 5.6.2
       vite: 7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-istanbul@4.1.10)(jsdom@29.1.1)(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.1)(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2))
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-istanbul@4.1.10)(jsdom@29.1.1)(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-istanbul@4.1.10)(jsdom@30.0.1)(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@22.20.1)(typescript@5.9.3))(vite@7.3.2(@types/node@22.20.1)(jiti@2.7.0)(less@4.6.7)(terser@5.51.2))
@@ -14630,7 +14642,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.20.1
       '@vitest/coverage-istanbul': 4.1.10(vitest@4.1.10)
-      jsdom: 29.1.1
+      jsdom: 30.0.1
     transitivePeerDependencies:
       - msw
 
@@ -14918,6 +14930,14 @@ snapshots:
   whatwg-mimetype@5.0.0: {}
 
   whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.1:
     dependencies:
       '@exodus/bytes': 1.15.1
       tr46: 6.0.0

--- a/src/shell/boards/board-container.test.tsx
+++ b/src/shell/boards/board-container.test.tsx
@@ -7,7 +7,7 @@ import { act, screen, waitFor, within } from '@testing-library/react';
 import { Input } from '@zextras/carbonio-design-system';
 import { reduce, sample, size } from 'lodash';
 
-import { BOARD_DEFAULT_POSITION, BoardContainer } from './board-container';
+import { BoardContainer } from './board-container';
 import {
 	BOARD_MIN_VISIBILITY,
 	HEADER_BAR_HEIGHT,
@@ -19,6 +19,8 @@ import { reopenBoards, useBoardStore } from '../../store/boards';
 import { ICONS, TESTID_SELECTORS } from '../../tests/constants';
 import { mockedApps, setupAppStore } from '../../tests/test-app-utils';
 import {
+	BOARD_DEFAULT_COMPUTED_POSITION,
+	BOARD_DEFAULT_COMPUTED_SIZE,
 	buildBoardSizeAndPosition,
 	buildMousePosition,
 	setupBoardStore,
@@ -614,9 +616,8 @@ describe('Board container', () => {
 			).toEqual({})
 		);
 		expect(board, 'reset board should return to the default size and position').toHaveStyle({
-			height: '70vh',
-			width: 'auto',
-			...BOARD_DEFAULT_POSITION
+			...BOARD_DEFAULT_COMPUTED_SIZE,
+			...BOARD_DEFAULT_COMPUTED_POSITION
 		});
 	});
 
@@ -805,9 +806,8 @@ describe('Board container', () => {
 			board,
 			'resetting an enlarged board should return it to the default size and position'
 		).toHaveStyle({
-			height: '70vh',
-			width: 'auto',
-			...BOARD_DEFAULT_POSITION
+			...BOARD_DEFAULT_COMPUTED_SIZE,
+			...BOARD_DEFAULT_COMPUTED_POSITION
 		});
 	});
 
@@ -832,8 +832,7 @@ describe('Board container', () => {
 			board,
 			'moving a default-size board should update its position and keep the default size'
 		).toHaveStyle({
-			height: '70vh',
-			width: 'auto',
+			...BOARD_DEFAULT_COMPUTED_SIZE,
 			left: 0,
 			top: 0
 		});
@@ -876,8 +875,7 @@ describe('Board container', () => {
 			board,
 			'moving a default-size board twice should keep the latest position and the default size'
 		).toHaveStyle({
-			height: '70vh',
-			width: 'auto',
+			...BOARD_DEFAULT_COMPUTED_SIZE,
 			left: `${boardNewPosition.left}px`,
 			top: `${boardNewPosition.top}px`
 		});
@@ -981,8 +979,7 @@ describe('Board container', () => {
 			board,
 			'moving after a reset should set the new position while keeping the default size'
 		).toHaveStyle({
-			height: '70vh',
-			width: 'auto',
+			...BOARD_DEFAULT_COMPUTED_SIZE,
 			left: 0,
 			top: 0
 		});
@@ -1038,8 +1035,7 @@ describe('Board container', () => {
 			board,
 			`${actionName} action should not fire when a move is performed on it, so the board keeps the moved position`
 		).toHaveStyle({
-			height: '70vh',
-			width: 'auto',
+			...BOARD_DEFAULT_COMPUTED_SIZE,
 			left: `${boardNewPosition.left}px`,
 			top: `${boardNewPosition.top}px`
 		});
@@ -1088,9 +1084,8 @@ describe('Board container', () => {
 			board,
 			'move should be ignored on an enlarged board, so reducing it returns to the default size and position'
 		).toHaveStyle({
-			height: '70vh',
-			width: 'auto',
-			...BOARD_DEFAULT_POSITION
+			...BOARD_DEFAULT_COMPUTED_SIZE,
+			...BOARD_DEFAULT_COMPUTED_POSITION
 		});
 	});
 
@@ -1109,9 +1104,8 @@ describe('Board container', () => {
 				board,
 				'pressing Space on the focused enlarge button should reduce the board to the default size and position'
 			).toHaveStyle({
-				height: '70vh',
-				width: 'auto',
-				...BOARD_DEFAULT_POSITION
+				...BOARD_DEFAULT_COMPUTED_SIZE,
+				...BOARD_DEFAULT_COMPUTED_POSITION
 			})
 		);
 	});

--- a/src/shell/shell-view.test.tsx
+++ b/src/shell/shell-view.test.tsx
@@ -5,7 +5,6 @@
  */
 import { act, screen, waitFor } from '@testing-library/react';
 
-import { BOARD_DEFAULT_POSITION } from './boards/board-container';
 import type { Border } from './hooks/useResize';
 import ShellView from './shell-view';
 import { HEADER_BAR_HEIGHT, LOCAL_STORAGE_BOARD_SIZE, PRIMARY_BAR_WIDTH } from '../constants';
@@ -13,6 +12,7 @@ import * as constants from '../constants';
 import { ICONS, TESTID_SELECTORS } from '../tests/constants';
 import { mockedApps, setupAppStore } from '../tests/test-app-utils';
 import {
+	BOARD_DEFAULT_COMPUTED_POSITION,
 	buildBoardSizeAndPosition,
 	buildMousePosition,
 	INITIAL_SIZE_AND_POS,
@@ -249,7 +249,7 @@ describe('Shell view', () => {
 			board2Element,
 			'a board re-opened after being closed should keep the resized size but reset to the default position'
 		).toHaveStyle({
-			...BOARD_DEFAULT_POSITION,
+			...BOARD_DEFAULT_COMPUTED_POSITION,
 			height: `${boardNewSizeAndPos.height}px`,
 			width: `${boardNewSizeAndPos.width}px`
 		});

--- a/src/tests/test-board-utils.ts
+++ b/src/tests/test-board-utils.ts
@@ -9,10 +9,38 @@ import { first, keys } from 'lodash';
 import { TESTID_SELECTORS } from './constants';
 import { mockedApps } from './test-app-utils';
 import { LOCAL_STORAGE_BOARD_SIZE } from '../constants';
+import { BOARD_DEFAULT_POSITION } from '../shell/boards/board-container';
 import type { Border } from '../shell/hooks/useResize';
 import { useBoardStore } from '../store/boards';
 import type { Board } from '../types/boards';
 import type { SizeAndPosition } from '../utils/utils';
+
+/*
+ * From jsdom 30 on, getComputedStyle resolves relative lengths the way browsers
+ * always have: `vh` against the viewport height, `rem` against the 16px root font
+ * size. Expectations that read computed styles (`toHaveStyle`) therefore have to be
+ * written in pixels; the ones reading emotion's rules (`toHaveStyleRule`) keep using
+ * the units the source declares.
+ */
+function remToPx(rem: number): string {
+	return `${rem * 16}px`;
+}
+
+function vhToPx(vh: number): string {
+	return `${(window.innerHeight * vh) / 100}px`;
+}
+
+/** The board default size (`height: 70vh; width: auto`) as getComputedStyle reports it. */
+export const BOARD_DEFAULT_COMPUTED_SIZE = {
+	height: vhToPx(70),
+	width: 'auto'
+};
+
+/** BOARD_DEFAULT_POSITION as getComputedStyle reports it. */
+export const BOARD_DEFAULT_COMPUTED_POSITION = {
+	...BOARD_DEFAULT_POSITION,
+	left: remToPx(1.5)
+};
 
 export type InitialSizeAndPosition = SizeAndPosition & {
 	clientLeft: number;


### PR DESCRIPTION
## What

Updates `jsdom` from `29.1.1` to `30.0.1` (test environment), and adjusts the board style expectations that its `getComputedStyle` fix invalidates.

| Package | Old | New |
|---|---|---|
| `jsdom` | `29.1.1` | `30.0.1` |

## Breaking change: the Node.js floor

jsdom 30's only declared breaking change is the minimum Node.js version, raised to `^22.22.2 || ^24.15.0 || >=26.0.0`. **No CI change is needed**, and the reason is worth recording:

`uiPipeline` derives its build container from `engines.node`, so `"node": "v22"` selects `pnpm-22`, which is registered in the Jenkins pod template (`infra-k3s`, `argocd-projects/dev-zextras/jenkins/jcasc/kubernetes-cloud.yaml`) as the image `guergeiro/pnpm:22-10`. That tag tracks the latest Node 22 line and currently resolves to **Node v22.23.1** — above the new floor. `engines.node` stays `v22`, since the pipeline reads only the major from it.

Locally the floor does bite: Node 22.22.0 is below `^22.22.2`, so a `nvm install 22` (→ 22.23.2) is needed. `.nvmrc` needs no change either, being `v22`.

## The behaviour change that actually required work

Listed under jsdom 30's non-breaking fixes:

> Fixed `getComputedStyle()` to convert length values into pixels.

This aligns jsdom with what browsers have always done — `getComputedStyle` reports resolved pixel values — but it invalidates any expectation written in the source's own units. Thirteen board tests asserted exactly that through `toHaveStyle`:

| Asserted | jsdom 29 returned | jsdom 30 returns |
|---|---|---|
| `height: 70vh` | `70vh` | `537.6px` (70% of jsdom's 768px viewport) |
| `left: 1.5rem` | `1.5rem` | `24px` (1.5 × 16px root font size) |

So the failures were the tests reading a value jsdom used not to resolve — not a regression in the board code. Confirmed by running the suite on `main` with Node 22.23.2 and jsdom 29: 688/688 green, so the failures are attributable to jsdom alone.

## How the expectations changed

Two helpers next to the other board test utilities (`src/tests/test-board-utils.ts`) resolve the units, and the default size and position are exported as the values `getComputedStyle` reports:

```ts
function remToPx(rem: number): string {
	return `${rem * 16}px`;
}

function vhToPx(vh: number): string {
	return `${(window.innerHeight * vh) / 100}px`;
}

export const BOARD_DEFAULT_COMPUTED_SIZE = { height: vhToPx(70), width: 'auto' };

export const BOARD_DEFAULT_COMPUTED_POSITION = {
	...BOARD_DEFAULT_POSITION,
	left: remToPx(1.5)
};
```

`BOARD_DEFAULT_COMPUTED_POSITION` spreads the source's own `BOARD_DEFAULT_POSITION` and overrides only the relative value, so the expectation keeps tracking the source for everything else. The change also removes the `height: '70vh', width: 'auto'` pair that was repeated across eight assertions.

**The `toHaveStyleRule` assertions are deliberately untouched.** That matcher (from `@emotion/jest`) inspects emotion's emitted CSS rules rather than computed styles, so it is unaffected by the jsdom fix and keeps documenting the intent in the units the source declares — `expect(board, 'board should start at the default 70vh height').toHaveStyleRule('height', '70vh')` still reads exactly as before.

## Verification

Run locally on Node 22.23.2:

| Check | Result |
|---|---|
| `pnpm test` | ✅ 39 files, 688 tests passed |
| `pnpm type-check` | ✅ clean |
| `pnpm lint` | ✅ 0 errors (5 pre-existing `sonarjs/cognitive-complexity` warnings) |
| `prettier` on the touched files | ✅ unchanged |
| `pnpm build:pkg` (`sdk build`) | ✅ compiled successfully |
| `pnpm build:lib` (api-extractor) | ✅ API report up to date |
| `pnpm install` | ✅ no `EBADENGINE` warning |

## Security

No advisory resolved or introduced — jsdom was not a source of any of the known advisories in the tree.

## Relation to the other open PRs

Independent of #903 (`remove unused webpack-cli`) and #904 (`remove unused @types/webpack`); all three are cut from `main` and touch disjoint sets of files, apart from `pnpm-lock.yaml`. Whichever merges last will need its lockfile refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
