### PR TITLE
chore(deps): update sonarqube-scanner to 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
 		"msw": "2.15.0",
 		"postcss-loader": "8.2.1",
 		"semantic-release": "25.0.9",
-		"sonarqube-scanner": "4.3.8",
+		"sonarqube-scanner": "4.4.0",
 		"typescript": "5.9.3",
 		"vitest": "4.1.11",
 		"vitest-fail-on-console": "0.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,8 +212,8 @@ importers:
         specifier: 25.0.9
         version: 25.0.9(typescript@5.9.3)
       sonarqube-scanner:
-        specifier: 4.3.8
-        version: 4.3.8
+        specifier: 4.4.0
+        version: 4.4.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -6228,8 +6228,8 @@ packages:
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
 
-  sonarqube-scanner@4.3.8:
-    resolution: {integrity: sha512-mkxxVmUJB5ammq4y8RJSWuW79MdV0tW5Bpi/rzi7hytu1ahyQwFdSoBlAoH1UsLSvfd1iM5R+5sjZbWlaOhGhA==}
+  sonarqube-scanner@4.4.0:
+    resolution: {integrity: sha512-j1hXSmkTCrFQbOL2BurcvLXS92uI+SetwLzwed11H0QJkFMam9nLvZM2hgg/QNelO/D902R+jJ09yLc7HhS/Yw==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -13740,7 +13740,7 @@ snapshots:
       uuid: 8.3.2
       websocket-driver: 0.7.5
 
-  sonarqube-scanner@4.3.8:
+  sonarqube-scanner@4.4.0:
     dependencies:
       adm-zip: 0.5.17
       axios: 1.17.0


### PR DESCRIPTION
## What

Updates `sonarqube-scanner` to `4.4.0` (patch/minor, dev dependency).

## Why

This is step 1 of a coordinated migration across the Carbonio UI projects, needed because **`sonarqube-scanner` 5.0.0 removes the `sonar` and `sonar-scanner` executable aliases** and ships only `sonar-scanner-npm`, while the shared pipeline still invokes the old name:

```groovy
// jenkins-lib-common — vars/uiPipeline.groovy, stage 'SonarQube analysis'
npx sonar-scanner -Dsonar.projectKey=${sonarProjectKey} ...
```

Bumping straight to 5.x would break the SonarQube analysis stage — and silently, since `npx sonar-scanner` would fall back to downloading the unrelated, abandoned `sonar-scanner` package (last published in 2022) instead of failing outright.

Version **4.4.0 is the bridge**: it ships the new `sonar-scanner-npm` executable **alongside** the deprecated `sonar` and `sonar-scanner` aliases, so it works with both the current pipeline and the updated one.

```
sonarqube-scanner@4.3.8  bin: sonar, sonar-scanner
sonarqube-scanner@4.4.0  bin: sonar, sonar-scanner, sonar-scanner-npm   ← this PR
sonarqube-scanner@5.0.0  bin: sonar-scanner-npm
```

The migration order is therefore:

1. **this PR** — every project to 4.4.0, no behaviour change
2. the shared library switches to `npx sonar-scanner-npm` (safe once every project is on 4.4.0)
3. projects can then move to 5.x at their own pace

## Impact

None on this project's behaviour. The scanner is a CI-only dev dependency, the CLI invocation is unchanged, and `4.4.0` still supports Node 18+. The `sonar-project.properties` file is untouched.

Verified: only `package.json` and `pnpm-lock.yaml` change, and the lockfile diff is limited to the scanner's own entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
